### PR TITLE
ci(fuzz): disable UBSan and MSan

### DIFF
--- a/.github/workflows/clusterfuzzlite.yml
+++ b/.github/workflows/clusterfuzzlite.yml
@@ -73,7 +73,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [address, undefined]
+        #sanitizer: [address, undefined]
+        sanitizer: [address]
     steps:
       - name: Build Fuzzers (${{ matrix.sanitizer }})
         id: build
@@ -106,7 +107,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [address, undefined, memory]
+        #sanitizer: [address, undefined, memory]
+        sanitizer: [address]
     steps:
       - name: Build Fuzzers (${{ matrix.sanitizer }})
         id: build


### PR DESCRIPTION
CI updates:

UndefinedBehaviorSanitizer (UBSan) - Not compatible with Rust fuzzing MemorySanitizer (MSan) - Requires full stdlib instrumentation


