### PR TITLE
feat: add MQTT benchmarking tool with io_uring support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["mqtt", "async", "tokio", "network", "mqtt_over_quic"]
 categories = ["network-programming", "asynchronous"]
 
 [workspace]
-members = [".", "mqtt_grpc_duality", "flowsdk_ffi"]
+members = [".", "mqtt_grpc_duality", "flowsdk_ffi", "mqtt_ring_bench"]
 exclude = ["fuzz", "release-small"]
 
 [dependencies]

--- a/mqtt_ring_bench/Cargo.toml
+++ b/mqtt_ring_bench/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "mqtt_ring_bench"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+description = "High-connection-count MQTT benchmarking tool using io_uring and sans-I/O client"
+
+[features]
+default = []
+quic = ["flowsdk/quic-proto", "dep:rustls", "dep:rustls-native-certs", "dep:rustls-pki-types"]
+
+[dependencies]
+flowsdk = { path = "..", default-features = false, features = ["strict-protocol-compliance"] }
+io-uring = "0.7"
+socket2 = "0.5"
+libc = "0.2"
+slab = "0.4"
+ctrlc = "3.4"
+clap = { version = "4.5", features = ["derive"] }
+
+# QUIC support (optional)
+rustls = { version = "0.23", optional = true, default-features = false, features = ["std", "ring"] }
+rustls-native-certs = { version = "0.7", optional = true }
+rustls-pki-types = { version = "1", optional = true }

--- a/mqtt_ring_bench/Cargo.toml
+++ b/mqtt_ring_bench/Cargo.toml
@@ -11,7 +11,6 @@ quic = ["flowsdk/quic-proto", "dep:rustls", "dep:rustls-native-certs", "dep:rust
 
 [dependencies]
 flowsdk = { path = "..", default-features = false, features = ["strict-protocol-compliance"] }
-io-uring = "0.7"
 socket2 = "0.5"
 libc = "0.2"
 slab = "0.4"
@@ -22,3 +21,9 @@ clap = { version = "4.5", features = ["derive"] }
 rustls = { version = "0.23", optional = true, default-features = false, features = ["std", "ring"] }
 rustls-native-certs = { version = "0.7", optional = true }
 rustls-pki-types = { version = "1", optional = true }
+
+# Linux-only: io_uring is the kernel async-I/O interface this bench is built on.
+# On non-Linux platforms the binary builds to a stub `main` that exits with an
+# informative message, so workspace `cargo build` / CI on macOS still succeeds.
+[target.'cfg(target_os = "linux")'.dependencies]
+io-uring = "0.7"

--- a/mqtt_ring_bench/README.md
+++ b/mqtt_ring_bench/README.md
@@ -1,0 +1,229 @@
+# mqtt_ring_bench
+
+High-connection-count MQTT publish benchmark using `io_uring` and FlowSDK's sans-I/O client.
+
+Designed for **100K+ concurrent connections** with minimal memory footprint. Traditional MQTT bench tools allocate ~256KB of kernel socket buffers per connection (25GB+ at 100K). This tool cuts that to **~8KB per connection** by combining:
+
+- **`NoIoMqttClient`** (sans-I/O) -- MQTT protocol handling decoupled from I/O
+- **`io_uring`** -- kernel-bypass async I/O with no per-syscall overhead
+- **Tiny socket buffers** -- `SO_RCVBUF`/`SO_SNDBUF` set to 2KB (configurable)
+- **Small parser buffers** -- 1.5KB (1 MTU) instead of the default 16KB
+
+## Memory Budget
+
+### TCP mode
+
+| Component | Per-Connection | 100K Total |
+|---|---|---|
+| NoIoMqttClient (parser + engine) | ~3.5 KB | 350 MB |
+| Kernel socket buffers | 4 KB | 400 MB |
+| Connection state | ~0.2 KB | 20 MB |
+| **Total** | **~8 KB** | **~770 MB** |
+
+### QUIC mode
+
+| Component | Per-Connection | 100K Total |
+|---|---|---|
+| QuicMqttEngine (MQTT + quinn-proto state) | ~10 KB | 1 GB |
+| UDP socket kernel overhead | ~0.5 KB | 50 MB |
+| Connection struct + send queue | ~1 KB | 100 MB |
+| **Total** | **~11.5 KB** | **~1.15 GB** |
+
+QUIC avoids TCP's mandatory send/recv buffers. The main cost is the quinn-proto `Connection` state (~6-8KB for TLS session + congestion control).
+
+## Requirements
+
+- **Linux 5.6+** (io_uring)
+- Raise file descriptor limit: `ulimit -n 200000`
+- For 100K+ connections to a single broker, use `--ifaddr` with multiple source IPs (each IP supports ~65K ephemeral ports)
+
+## Build
+
+Requires Rust 1.70+. Linux-only (io_uring).
+
+```bash
+# Native build on Linux (TCP only)
+cargo build -p mqtt_ring_bench --release
+
+# With QUIC support (adds rustls + quinn-proto)
+cargo build -p mqtt_ring_bench --features quic --release
+
+# Cross-compile from macOS using zig
+cargo install cargo-zigbuild
+cargo zigbuild -p mqtt_ring_bench --target aarch64-unknown-linux-musl --release
+cargo zigbuild -p mqtt_ring_bench --features quic --target aarch64-unknown-linux-musl --release
+cargo zigbuild -p mqtt_ring_bench --target x86_64-unknown-linux-musl --release
+```
+
+The output is a statically linked binary (~800KB without QUIC, ~2.3MB with QUIC) with no runtime dependencies.
+
+## Usage
+
+```
+mqtt_ring_bench [OPTIONS]
+
+OPTIONS:
+    --host <HOST>             Broker hostname [default: localhost]
+    --port <PORT>             Broker port [default: 1883]
+    --clients <N>             Concurrent connections [default: 1000]
+    --messages <N>            Messages per client [default: 1000]
+    --qos <0|1|2>             QoS level [default: 0]
+    --topic <TOPIC>           Base topic [default: bench/test]
+    --payload-size <BYTES>    Payload size [default: 256]
+    --interval <MS>           Delay between publishes per client, 0 = max speed [default: 0]
+    --keep-alive <SECS>       MQTT keep-alive [default: 60]
+    --mqtt-version <3|4|5>    Protocol version [default: 5]
+    --workers <N>             Worker threads [default: num_cpus]
+    --connect-rate <N>        Connections/sec during ramp-up [default: 1000]
+    --socket-buf <BYTES>      SO_RCVBUF/SO_SNDBUF per socket [default: 2048]
+    --parser-buf <BYTES>      MQTT parser buffer per connection [default: 1500]
+    --ifaddr <ADDRS>          Source IPs to bind (round-robin)
+    --quic                    Use MQTT over QUIC (UDP) instead of TCP
+    --quic-insecure           Skip TLS certificate verification (testing only)
+    --server-name <NAME>      TLS SNI server name [default: --host value]
+    -h, --help                Print help
+```
+
+## Examples
+
+```bash
+# Quick test: 100 clients, 100 messages each, QoS 0
+mqtt_ring_bench --host broker.emqx.io --clients 100 --messages 100
+
+# QoS 1 with latency measurement
+mqtt_ring_bench --host 10.0.0.1 --clients 1000 --messages 500 --qos 1
+
+# 100K connections with multiple source IPs
+mqtt_ring_bench --host 10.0.0.1 --clients 100000 --messages 10 \
+    --ifaddr 192.168.1.100-200 --connect-rate 5000
+
+# Max throughput: large payload, QoS 0, 8 workers
+mqtt_ring_bench --host 10.0.0.1 --clients 5000 --messages 100000 \
+    --payload-size 1024 --workers 8
+
+# QUIC: connect to EMQX QUIC port (requires --features quic build)
+mqtt_ring_bench --quic --quic-insecure --host broker.emqx.io --port 14567 \
+    --clients 10 --messages 100 --qos 1
+
+# QUIC: with custom TLS SNI name
+mqtt_ring_bench --quic --host 10.0.0.1 --port 14567 \
+    --server-name mqtt.example.com --clients 1000 --messages 500
+```
+
+### Source IP binding (`--ifaddr`)
+
+A single source IP can only open ~65K connections to the same destination. Use `--ifaddr` to distribute connections across multiple IPs:
+
+```bash
+# Single IP
+--ifaddr 192.168.1.100
+
+# Comma-separated list
+--ifaddr 192.168.1.100,192.168.1.101,192.168.1.102
+
+# Range (expands last octet)
+--ifaddr 192.168.1.100-200    # 101 IPs -> up to ~6.5M connections
+```
+
+Connections are round-robin distributed across the source addresses.
+
+## Output
+
+### Live stats (printed every second)
+
+```
+[  5s] Connected: 5000/100000 | Sent: 0 | Acked: 0 | Errors: 0 | Rate: 0 msg/s
+[105s] Connected: 100000/100000 | Sent: 4500000 | Acked: 4499800 | Errors: 3 | Rate: 52000 msg/s
+```
+
+### Final summary
+
+```
+============================================================
+                    MQTT Bench Results
+============================================================
+  Broker:          10.0.0.1:1883
+  MQTT Version:    5
+  Clients:         100000
+  Workers:         8
+  QoS:             1
+  Payload Size:    256 bytes
+  Messages/Client: 100
+  Socket Buffers:  2048 bytes
+  Parser Buffer:   1500 bytes
+------------------------------------------------------------
+  Total Sent:      10000000
+  Total Acked:     9999997
+  Errors:          3
+  Duration:        192.34 s
+  Throughput:      51991.23 msg/s
+------------------------------------------------------------
+  Latency (send -> ACK):
+    Min:           0.08 ms
+    Max:           45.21 ms
+    Avg:           1.87 ms
+    P50:           1.12 ms
+    P95:           5.43 ms
+    P99:           12.76 ms
+============================================================
+```
+
+## Architecture
+
+```
+main thread
+  ├── parse args, resolve broker address
+  ├── (if --quic) build TLS config (shared Arc<rustls::ClientConfig>)
+  ├── spawn N worker threads (std::thread, one per core)
+  │     ├── Worker 0: io_uring instance + connections [0..K)
+  │     ├── Worker 1: io_uring instance + connections [K..2K)
+  │     └── ...
+  ├── spawn 1 stats reporter thread (prints every 1s)
+  └── join all, print final summary
+```
+
+No async runtime (no tokio). Each worker runs a synchronous `io_uring` event loop managing thousands of connections.
+
+**TCP mode** (default): Each connection wraps a `NoIoMqttClient` for protocol handling and feeds bytes in/out via io_uring send/recv operations.
+
+**QUIC mode** (`--quic`): Each connection wraps a `QuicMqttEngine` (sans-I/O QUIC+MQTT engine) with its own UDP socket. The UDP socket is "connected" via `libc::connect()` so the same io_uring `Send`/`Recv` opcodes work for both TCP and UDP. The QUIC state machine is driven by 10ms timer ticks (vs 500ms for TCP).
+
+### Connection state machine
+
+**TCP:**
+```
+TcpConnecting -> MqttConnecting -> Publishing -> Draining -> Disconnecting -> Done
+```
+
+**QUIC:**
+```
+Handshaking -> Publishing -> Draining -> Disconnecting -> Done
+```
+No separate TCP connect phase — QUIC handshake happens via UDP datagrams. The engine internally handles QUIC handshake + MQTT CONNECT once the QUIC connection is established.
+
+### Latency measurement
+
+- **QoS 1/2**: Measures wall-clock time from `publish()` call to `MqttEvent::Published` (PUBACK/PUBCOMP). FIFO ordering guaranteed by MQTT spec.
+- **QoS 0**: Measures enqueue time (no broker ack). Labeled separately in output.
+
+## Kernel Tuning (for 100K+)
+
+```bash
+# File descriptor limit
+ulimit -n 500000
+
+# Ephemeral port range
+sysctl -w net.ipv4.ip_local_port_range="1024 65535"
+
+# Connection backlog
+sysctl -w net.core.somaxconn=65535
+
+# TCP memory (optional, reduces per-socket overhead further)
+sysctl -w net.ipv4.tcp_mem="8388608 8388608 8388608"
+sysctl -w net.ipv4.tcp_rmem="1024 2048 4096"
+sysctl -w net.ipv4.tcp_wmem="1024 2048 4096"
+```
+
+## License
+
+MPL-2.0

--- a/mqtt_ring_bench/src/config.rs
+++ b/mqtt_ring_bench/src/config.rs
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use clap::{ArgAction, Parser};
+use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
+
+pub struct BenchConfig {
+    pub addr: SocketAddr,
+    pub host: String,
+    pub port: u16,
+    pub clients: usize,
+    pub messages: u64,
+    pub qos: u8,
+    pub topic: String,
+    pub payload_size: usize,
+    pub interval_ms: u64,
+    pub keep_alive: u16,
+    pub mqtt_version: u8,
+    pub workers: usize,
+    pub connect_rate: usize,
+    pub socket_buf: usize,
+    pub parser_buf: usize,
+    /// Source IP addresses to bind outgoing connections to (round-robin).
+    /// Empty means OS picks the source address.
+    pub ifaddrs: Vec<IpAddr>,
+    /// Use MQTT over QUIC (UDP) instead of TCP.
+    pub quic: bool,
+    /// Skip TLS certificate verification for QUIC (testing only).
+    pub quic_insecure: bool,
+    /// TLS SNI server name for QUIC. Defaults to --host value.
+    pub server_name: Option<String>,
+}
+
+#[derive(Debug, Parser)]
+#[command(name = "mqtt_ring_bench", about = "High-connection-count MQTT publish benchmark (io_uring)")]
+struct BenchArgs {
+    #[arg(long, default_value = "localhost")]
+    host: String,
+
+    #[arg(long, default_value_t = 1883)]
+    port: u16,
+
+    #[arg(long, default_value_t = 1000)]
+    clients: usize,
+
+    #[arg(long, default_value_t = 1000)]
+    messages: u64,
+
+    #[arg(long, default_value_t = 0)]
+    qos: u8,
+
+    #[arg(long, default_value = "bench/test")]
+    topic: String,
+
+    #[arg(long = "payload-size", default_value_t = 256)]
+    payload_size: usize,
+
+    #[arg(long, default_value_t = 0)]
+    interval: u64,
+
+    #[arg(long = "keep-alive", default_value_t = 60)]
+    keep_alive: u16,
+
+    #[arg(long = "mqtt-version", default_value_t = 5)]
+    mqtt_version: u8,
+
+    #[arg(long, default_value_t = num_cpus())]
+    workers: usize,
+
+    #[arg(long = "connect-rate", default_value_t = 1000)]
+    connect_rate: usize,
+
+    #[arg(long = "socket-buf", default_value_t = 2048)]
+    socket_buf: usize,
+
+    #[arg(long = "parser-buf", default_value_t = 1500)]
+    parser_buf: usize,
+
+    /// Source IP addresses to bind outgoing connections to (round-robin).
+    /// Supports single, comma-separated, or last-octet range syntax.
+    #[arg(long = "ifaddr")]
+    ifaddr: Option<String>,
+
+    #[arg(long, action = ArgAction::SetTrue)]
+    quic: bool,
+
+    #[arg(long = "quic-insecure", action = ArgAction::SetTrue)]
+    quic_insecure: bool,
+
+    #[arg(long = "server-name")]
+    server_name: Option<String>,
+}
+
+impl Default for BenchConfig {
+    fn default() -> Self {
+        Self {
+            addr: SocketAddr::from(([127, 0, 0, 1], 1883)),
+            host: "localhost".to_string(),
+            port: 1883,
+            clients: 1000,
+            messages: 1000,
+            qos: 0,
+            topic: "bench/test".to_string(),
+            payload_size: 256,
+            interval_ms: 0,
+            keep_alive: 60,
+            mqtt_version: 5,
+            workers: num_cpus(),
+            connect_rate: 1000,
+            socket_buf: 2048,
+            parser_buf: 1500,
+            ifaddrs: Vec::new(),
+            quic: false,
+            quic_insecure: false,
+            server_name: None,
+        }
+    }
+}
+
+fn num_cpus() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+}
+
+pub fn parse_args() -> BenchConfig {
+    let args = BenchArgs::parse();
+
+    #[cfg(not(feature = "quic"))]
+    if args.quic {
+        eprintln!("Error: --quic requires the 'quic' feature. Rebuild with: --features quic");
+        std::process::exit(1);
+    }
+
+    let mut config = BenchConfig {
+        host: args.host,
+        port: args.port,
+        clients: args.clients,
+        messages: args.messages,
+        qos: args.qos,
+        topic: args.topic,
+        payload_size: args.payload_size,
+        interval_ms: args.interval,
+        keep_alive: args.keep_alive,
+        mqtt_version: args.mqtt_version,
+        workers: args.workers,
+        connect_rate: args.connect_rate,
+        socket_buf: args.socket_buf,
+        parser_buf: args.parser_buf,
+        ifaddrs: Vec::new(),
+        quic: args.quic,
+        quic_insecure: args.quic_insecure,
+        server_name: args.server_name,
+        ..BenchConfig::default()
+    };
+
+    if let Some(val) = args.ifaddr {
+        config.ifaddrs = parse_ifaddrs(&val);
+        if config.ifaddrs.is_empty() {
+            eprintln!("Error: no valid addresses parsed from --ifaddr '{}'", val);
+            std::process::exit(1);
+        }
+    }
+
+    let addr_str = format!("{}:{}", config.host, config.port);
+    config.addr = addr_str
+        .to_socket_addrs()
+        .unwrap_or_else(|e| {
+            eprintln!("Error resolving {}: {}", addr_str, e);
+            std::process::exit(1);
+        })
+        .next()
+        .unwrap_or_else(|| {
+            eprintln!("Error: no addresses found for {}", addr_str);
+            std::process::exit(1);
+        });
+
+    if config.workers == 0 {
+        config.workers = 1;
+    }
+    if config.clients == 0 {
+        eprintln!("Error: --clients must be > 0");
+        std::process::exit(1);
+    }
+    if config.qos > 2 {
+        eprintln!("Error: --qos must be 0, 1, or 2");
+        std::process::exit(1);
+    }
+    if !matches!(config.mqtt_version, 3 | 4 | 5) {
+        eprintln!("Error: --mqtt-version must be 3, 4, or 5");
+        std::process::exit(1);
+    }
+
+    config
+}
+
+/// Parse --ifaddr value. Supports:
+///   Single:   192.168.1.100
+///   List:     192.168.1.100,192.168.1.101,192.168.1.102
+///   Range:    192.168.1.100-200   (expands last octet from 100 to 200 inclusive)
+fn parse_ifaddrs(val: &str) -> Vec<IpAddr> {
+    let mut addrs = Vec::new();
+    for part in val.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        // Check for range notation: a.b.c.X-Y
+        if let Some(dash_pos) = part.rfind('-') {
+            // Ensure dash is after the last dot (range on last octet)
+            if let Some(dot_pos) = part.rfind('.') {
+                if dash_pos > dot_pos {
+                    let prefix = &part[..dot_pos + 1]; // "a.b.c."
+                    let start_str = &part[dot_pos + 1..dash_pos];
+                    let end_str = &part[dash_pos + 1..];
+                    if let (Ok(start), Ok(end)) =
+                        (start_str.parse::<u8>(), end_str.parse::<u8>())
+                    {
+                        for i in start..=end {
+                            let ip_str = format!("{}{}", prefix, i);
+                            if let Ok(ip) = ip_str.parse::<IpAddr>() {
+                                addrs.push(ip);
+                            }
+                        }
+                        continue;
+                    }
+                }
+            }
+        }
+        // Plain IP address
+        match part.parse::<IpAddr>() {
+            Ok(ip) => addrs.push(ip),
+            Err(e) => {
+                eprintln!("Warning: invalid IP address '{}': {}", part, e);
+            }
+        }
+    }
+    addrs
+}

--- a/mqtt_ring_bench/src/config.rs
+++ b/mqtt_ring_bench/src/config.rs
@@ -188,7 +188,7 @@ pub fn parse_args() -> BenchConfig {
         eprintln!("Error: --qos must be 0, 1, or 2");
         std::process::exit(1);
     }
-    if !matches!(config.mqtt_version, 3 | 4 | 5) {
+    if !matches!(config.mqtt_version, 3..=5) {
         eprintln!("Error: --mqtt-version must be 3, 4, or 5");
         std::process::exit(1);
     }

--- a/mqtt_ring_bench/src/config.rs
+++ b/mqtt_ring_bench/src/config.rs
@@ -31,7 +31,10 @@ pub struct BenchConfig {
 }
 
 #[derive(Debug, Parser)]
-#[command(name = "mqtt_ring_bench", about = "High-connection-count MQTT publish benchmark (io_uring)")]
+#[command(
+    name = "mqtt_ring_bench",
+    about = "High-connection-count MQTT publish benchmark (io_uring)"
+)]
 struct BenchArgs {
     #[arg(long, default_value = "localhost")]
     host: String,
@@ -212,9 +215,7 @@ fn parse_ifaddrs(val: &str) -> Vec<IpAddr> {
                     let prefix = &part[..dot_pos + 1]; // "a.b.c."
                     let start_str = &part[dot_pos + 1..dash_pos];
                     let end_str = &part[dash_pos + 1..];
-                    if let (Ok(start), Ok(end)) =
-                        (start_str.parse::<u8>(), end_str.parse::<u8>())
-                    {
+                    if let (Ok(start), Ok(end)) = (start_str.parse::<u8>(), end_str.parse::<u8>()) {
                         for i in start..=end {
                             let ip_str = format!("{}{}", prefix, i);
                             if let Ok(ip) = ip_str.parse::<IpAddr>() {

--- a/mqtt_ring_bench/src/connection.rs
+++ b/mqtt_ring_bench/src/connection.rs
@@ -201,6 +201,12 @@ impl Connection {
         drained
     }
 
+    /// Next deadline the engine wants us to wake up at, if any.
+    /// Used by the worker to size its io_uring wait timeout.
+    pub fn next_tick_at(&self) -> Option<Instant> {
+        self.mqtt.next_tick_at()
+    }
+
     pub fn handle_tick(&mut self) -> Vec<MqttEvent> {
         let now = Instant::now();
         if let Some(next) = self.mqtt.next_tick_at() {

--- a/mqtt_ring_bench/src/connection.rs
+++ b/mqtt_ring_bench/src/connection.rs
@@ -1,0 +1,508 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use flowsdk::mqtt_client::{MqttClientOptions, MqttEvent, NoIoMqttClient, PublishCommand};
+#[cfg(feature = "quic")]
+use flowsdk::mqtt_client::engine::QuicMqttEngine;
+use std::collections::VecDeque;
+#[cfg(feature = "quic")]
+use std::net::SocketAddr;
+use std::os::fd::RawFd;
+use std::time::{Duration, Instant};
+
+use crate::config::BenchConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnState {
+    TcpConnecting,
+    MqttConnecting,
+    Publishing,
+    Draining,
+    Disconnecting,
+    Done,
+    Failed,
+}
+
+pub struct Connection {
+    pub fd: RawFd,
+    pub mqtt: NoIoMqttClient,
+    pub state: ConnState,
+    pub send_buf: Vec<u8>,
+    pub send_offset: usize,
+    pub recv_buf: Vec<u8>,
+    pub messages_sent: u64,
+    pub messages_acked: u64,
+    pub messages_target: u64,
+    pub latency_pending: VecDeque<Instant>,
+    pub latency_samples: Vec<Duration>,
+    pub next_publish_at: Option<Instant>,
+    pub recv_pending: bool,
+    pub send_pending: bool,
+    pub client_index: usize,
+    pub drain_deadline: Option<Instant>,
+}
+
+impl Connection {
+    pub fn new(fd: RawFd, client_index: usize, config: &BenchConfig) -> Self {
+        let peer = format!("{}:{}", config.host, config.port);
+        let client_id = format!("mqtt_ring_bench_{}", client_index);
+        let options = MqttClientOptions::builder()
+            .peer(&peer)
+            .client_id(&client_id)
+            .keep_alive(config.keep_alive)
+            .mqtt_version(config.mqtt_version)
+            .clean_start(true)
+            .reconnect(false)
+            .auto_ack(true)
+            .parser_buffer_size(config.parser_buf)
+            .max_outgoing_packet_count(config.messages.min(10_000) as usize)
+            .max_event_count(1000)
+            .build();
+
+        Self {
+            fd,
+            mqtt: NoIoMqttClient::new(options),
+            state: ConnState::TcpConnecting,
+            send_buf: Vec::new(),
+            send_offset: 0,
+            recv_buf: vec![0u8; config.parser_buf.max(1500)],
+            messages_sent: 0,
+            messages_acked: 0,
+            messages_target: config.messages,
+            latency_pending: VecDeque::new(),
+            latency_samples: Vec::new(),
+            next_publish_at: None,
+            recv_pending: false,
+            send_pending: false,
+            client_index,
+            drain_deadline: None,
+        }
+    }
+
+    pub fn initiate_mqtt_connect(&mut self) {
+        self.mqtt.connect();
+        self.take_outgoing();
+        self.state = ConnState::MqttConnecting;
+    }
+
+    pub fn handle_incoming(&mut self, data: &[u8]) -> Vec<MqttEvent> {
+        self.mqtt.handle_incoming(data)
+    }
+
+    pub fn try_publish(&mut self, config: &BenchConfig) -> bool {
+        if self.state != ConnState::Publishing {
+            return false;
+        }
+        if self.messages_sent >= self.messages_target {
+            return false;
+        }
+        if self.send_offset < self.send_buf.len() {
+            return false;
+        }
+        if let Some(next) = self.next_publish_at {
+            if Instant::now() < next {
+                return false;
+            }
+        }
+
+        let topic = format!("{}/{}", config.topic, self.client_index);
+        let payload = vec![0x42u8; config.payload_size];
+        let cmd = PublishCommand::builder()
+            .topic(&topic)
+            .payload(payload)
+            .qos(config.qos)
+            .build();
+        let cmd = match cmd {
+            Ok(c) => c,
+            Err(_) => return false,
+        };
+
+        if config.qos > 0 {
+            self.latency_pending.push_back(Instant::now());
+        }
+
+        match self.mqtt.publish(cmd) {
+            Ok(_) => {
+                self.messages_sent += 1;
+                self.take_outgoing();
+                if config.interval_ms > 0 {
+                    self.next_publish_at =
+                        Some(Instant::now() + Duration::from_millis(config.interval_ms));
+                }
+                true
+            }
+            Err(_) => {
+                if config.qos > 0 {
+                    self.latency_pending.pop_back();
+                }
+                false
+            }
+        }
+    }
+
+    pub fn process_events(&mut self, events: Vec<MqttEvent>) -> EventOutcome {
+        let mut outcome = EventOutcome::default();
+        for event in events {
+            match event {
+                MqttEvent::Connected(result) => {
+                    if result.is_success() {
+                        self.state = ConnState::Publishing;
+                        outcome.connected = true;
+                    } else {
+                        self.state = ConnState::Failed;
+                        outcome.error = true;
+                    }
+                }
+                MqttEvent::Published(result) => {
+                    if result.is_success() {
+                        self.messages_acked += 1;
+                        outcome.acked += 1;
+                        if let Some(sent_at) = self.latency_pending.pop_front() {
+                            self.latency_samples.push(sent_at.elapsed());
+                        }
+                    } else {
+                        outcome.error = true;
+                    }
+                }
+                MqttEvent::Error(_) => {
+                    outcome.error = true;
+                }
+                MqttEvent::Disconnected(_) | MqttEvent::ReconnectNeeded => {
+                    if self.state != ConnState::Disconnecting && self.state != ConnState::Done {
+                        self.state = ConnState::Failed;
+                        outcome.error = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+        outcome
+    }
+
+    pub fn check_publish_complete(&mut self) {
+        if self.state == ConnState::Publishing && self.messages_sent >= self.messages_target {
+            self.state = ConnState::Draining;
+            self.drain_deadline = Some(Instant::now() + Duration::from_secs(10));
+        }
+    }
+
+    pub fn check_drain_complete(&mut self) -> bool {
+        if self.state != ConnState::Draining {
+            return false;
+        }
+        let drained = self.messages_acked >= self.messages_sent
+            || self
+                .drain_deadline
+                .map_or(false, |d| Instant::now() >= d);
+        if drained {
+            self.mqtt.disconnect();
+            self.take_outgoing();
+            self.state = ConnState::Disconnecting;
+        }
+        drained
+    }
+
+    pub fn handle_tick(&mut self) -> Vec<MqttEvent> {
+        let now = Instant::now();
+        if let Some(next) = self.mqtt.next_tick_at() {
+            if now >= next {
+                let events = self.mqtt.handle_tick(now);
+                self.take_outgoing();
+                return events;
+            }
+        }
+        Vec::new()
+    }
+
+    pub fn take_outgoing(&mut self) {
+        let out = self.mqtt.take_outgoing();
+        if !out.is_empty() {
+            if self.send_offset >= self.send_buf.len() {
+                self.send_buf = out;
+                self.send_offset = 0;
+            } else {
+                self.send_buf.extend_from_slice(&out);
+            }
+        }
+    }
+
+    pub fn has_pending_send(&self) -> bool {
+        self.send_offset < self.send_buf.len()
+    }
+
+    pub fn pending_send_slice(&self) -> &[u8] {
+        &self.send_buf[self.send_offset..]
+    }
+
+    pub fn advance_send(&mut self, n: usize) {
+        self.send_offset += n;
+        if self.send_offset >= self.send_buf.len() {
+            self.send_buf.clear();
+            self.send_offset = 0;
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct EventOutcome {
+    pub connected: bool,
+    pub acked: u64,
+    pub error: bool,
+}
+
+// ---------------------------------------------------------------------------
+// QUIC Connection (feature-gated)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "quic")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuicConnState {
+    /// Initial QUIC handshake datagrams being exchanged.
+    Handshaking,
+    /// MQTT PUBLISH phase.
+    Publishing,
+    /// All publishes sent; waiting for remaining ACKs.
+    Draining,
+    /// DISCONNECT sent; finishing up.
+    Disconnecting,
+    Done,
+    Failed,
+}
+
+#[cfg(feature = "quic")]
+pub struct QuicConnection {
+    pub fd: RawFd,
+    pub engine: QuicMqttEngine,
+    pub state: QuicConnState,
+    pub messages_sent: u64,
+    pub messages_acked: u64,
+    pub messages_target: u64,
+    pub latency_pending: VecDeque<Instant>,
+    pub latency_samples: Vec<Duration>,
+    pub next_publish_at: Option<Instant>,
+    pub recv_buf: Vec<u8>,
+    pub recv_pending: bool,
+    /// Queue of outgoing UDP datagrams waiting to be sent.
+    pub send_queue: VecDeque<Vec<u8>>,
+    /// True while an io_uring Send SQE is in-flight for this connection.
+    pub send_pending: bool,
+    pub client_index: usize,
+    pub drain_deadline: Option<Instant>,
+    pub server_addr: SocketAddr,
+}
+
+#[cfg(feature = "quic")]
+impl QuicConnection {
+    pub fn new(
+        fd: RawFd,
+        client_index: usize,
+        config: &BenchConfig,
+        server_addr: SocketAddr,
+    ) -> Result<Self, String> {
+        let peer = format!("{}:{}", config.host, config.port);
+        let client_id = format!("mqtt_ring_bench_{}", client_index);
+        let options = MqttClientOptions::builder()
+            .peer(&peer)
+            .client_id(&client_id)
+            .keep_alive(config.keep_alive)
+            .mqtt_version(config.mqtt_version)
+            .clean_start(true)
+            .reconnect(false)
+            .auto_ack(true)
+            .parser_buffer_size(config.parser_buf)
+            .max_outgoing_packet_count(config.messages.min(10_000) as usize)
+            .max_event_count(1000)
+            .build();
+
+        let engine =
+            QuicMqttEngine::new(options).map_err(|e| format!("QuicMqttEngine::new: {}", e))?;
+
+        Ok(Self {
+            fd,
+            engine,
+            state: QuicConnState::Handshaking,
+            messages_sent: 0,
+            messages_acked: 0,
+            messages_target: config.messages,
+            latency_pending: VecDeque::new(),
+            latency_samples: Vec::new(),
+            next_publish_at: None,
+            recv_buf: vec![0u8; 2048], // UDP datagrams fit in ~1.5KB
+            recv_pending: false,
+            send_queue: VecDeque::new(),
+            send_pending: false,
+            client_index,
+            drain_deadline: None,
+            server_addr,
+        })
+    }
+
+    /// Start the QUIC handshake. Must be called after socket creation.
+    /// Takes the TLS crypto config and produces initial handshake datagrams.
+    pub fn initiate_quic_connect(
+        &mut self,
+        crypto: rustls::ClientConfig,
+        server_name: &str,
+        now: Instant,
+    ) -> Result<(), String> {
+        self.engine
+            .connect(self.server_addr, server_name, crypto, now)
+            .map_err(|e| format!("QUIC connect: {}", e))?;
+        // Drive the engine once to produce the Initial packet.
+        let _ = self.engine.handle_tick(now);
+        self.drain_outgoing_datagrams();
+        Ok(())
+    }
+
+    /// Move outgoing datagrams from the engine into our send_queue.
+    pub fn drain_outgoing_datagrams(&mut self) {
+        let datagrams = self.engine.take_outgoing_datagrams();
+        for (_dest, data) in datagrams {
+            self.send_queue.push_back(data);
+        }
+    }
+
+    /// Feed a received UDP datagram into the QUIC engine.
+    pub fn handle_datagram(&mut self, data: &[u8], now: Instant) -> Vec<MqttEvent> {
+        self.engine
+            .handle_datagram(data.to_vec(), self.server_addr, now);
+        let events = self.engine.handle_tick(now);
+        self.drain_outgoing_datagrams();
+        events
+    }
+
+    /// Drive the QUIC + MQTT state machines forward.
+    pub fn handle_tick(&mut self, now: Instant) -> Vec<MqttEvent> {
+        let events = self.engine.handle_tick(now);
+        self.drain_outgoing_datagrams();
+        events
+    }
+
+    pub fn try_publish(&mut self, config: &BenchConfig, now: Instant) -> bool {
+        if self.state != QuicConnState::Publishing {
+            return false;
+        }
+        if self.messages_sent >= self.messages_target {
+            return false;
+        }
+        if let Some(next) = self.next_publish_at {
+            if now < next {
+                return false;
+            }
+        }
+
+        let topic = format!("{}/{}", config.topic, self.client_index);
+        let payload = vec![0x42u8; config.payload_size];
+        let cmd = PublishCommand::builder()
+            .topic(&topic)
+            .payload(payload)
+            .qos(config.qos)
+            .build();
+        let cmd = match cmd {
+            Ok(c) => c,
+            Err(_) => return false,
+        };
+
+        if config.qos > 0 {
+            self.latency_pending.push_back(now);
+        }
+
+        match self.engine.publish(cmd) {
+            Ok(_) => {
+                self.messages_sent += 1;
+                // Drive engine to push MQTT data into QUIC stream and produce datagrams.
+                let _ = self.engine.handle_tick(now);
+                self.drain_outgoing_datagrams();
+                if config.interval_ms > 0 {
+                    self.next_publish_at =
+                        Some(now + Duration::from_millis(config.interval_ms));
+                }
+                true
+            }
+            Err(_) => {
+                if config.qos > 0 {
+                    self.latency_pending.pop_back();
+                }
+                false
+            }
+        }
+    }
+
+    pub fn process_events(&mut self, events: Vec<MqttEvent>) -> EventOutcome {
+        let mut outcome = EventOutcome::default();
+        for event in events {
+            match event {
+                MqttEvent::Connected(result) => {
+                    if result.is_success() {
+                        self.state = QuicConnState::Publishing;
+                        outcome.connected = true;
+                    } else {
+                        self.state = QuicConnState::Failed;
+                        outcome.error = true;
+                    }
+                }
+                MqttEvent::Published(result) => {
+                    if result.is_success() {
+                        self.messages_acked += 1;
+                        outcome.acked += 1;
+                        if let Some(sent_at) = self.latency_pending.pop_front() {
+                            self.latency_samples.push(sent_at.elapsed());
+                        }
+                    } else {
+                        outcome.error = true;
+                    }
+                }
+                MqttEvent::Error(_) => {
+                    outcome.error = true;
+                }
+                MqttEvent::Disconnected(_) | MqttEvent::ReconnectNeeded => {
+                    if self.state != QuicConnState::Disconnecting
+                        && self.state != QuicConnState::Done
+                    {
+                        self.state = QuicConnState::Failed;
+                        outcome.error = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+        outcome
+    }
+
+    pub fn check_publish_complete(&mut self) {
+        if self.state == QuicConnState::Publishing
+            && self.messages_sent >= self.messages_target
+        {
+            self.state = QuicConnState::Draining;
+            self.drain_deadline = Some(Instant::now() + Duration::from_secs(10));
+        }
+    }
+
+    pub fn check_drain_complete(&mut self, now: Instant) -> bool {
+        if self.state != QuicConnState::Draining {
+            return false;
+        }
+        let drained = self.messages_acked >= self.messages_sent
+            || self.drain_deadline.map_or(false, |d| now >= d);
+        if drained {
+            self.engine.disconnect();
+            let _ = self.engine.handle_tick(now);
+            self.drain_outgoing_datagrams();
+            self.state = QuicConnState::Disconnecting;
+        }
+        drained
+    }
+
+    pub fn has_pending_send(&self) -> bool {
+        !self.send_queue.is_empty()
+    }
+
+    /// Get the front datagram to send. Returns None if queue is empty.
+    pub fn front_send_datagram(&self) -> Option<&[u8]> {
+        self.send_queue.front().map(|v| v.as_slice())
+    }
+
+    /// Pop the front datagram after a successful send.
+    pub fn pop_front_datagram(&mut self) {
+        self.send_queue.pop_front();
+    }
+}

--- a/mqtt_ring_bench/src/connection.rs
+++ b/mqtt_ring_bench/src/connection.rs
@@ -166,11 +166,11 @@ impl Connection {
                 MqttEvent::Error(_) => {
                     outcome.error = true;
                 }
-                MqttEvent::Disconnected(_) | MqttEvent::ReconnectNeeded => {
-                    if self.state != ConnState::Disconnecting && self.state != ConnState::Done {
-                        self.state = ConnState::Failed;
-                        outcome.error = true;
-                    }
+                MqttEvent::Disconnected(_) | MqttEvent::ReconnectNeeded
+                    if self.state != ConnState::Disconnecting && self.state != ConnState::Done =>
+                {
+                    self.state = ConnState::Failed;
+                    outcome.error = true;
                 }
                 _ => {}
             }
@@ -190,7 +190,7 @@ impl Connection {
             return false;
         }
         let drained = self.messages_acked >= self.messages_sent
-            || self.drain_deadline.map_or(false, |d| Instant::now() >= d);
+            || self.drain_deadline.is_some_and(|d| Instant::now() >= d);
         if drained {
             self.mqtt.disconnect();
             self.take_outgoing();
@@ -457,14 +457,14 @@ impl QuicConnection {
                 MqttEvent::Error(_) => {
                     outcome.error = true;
                 }
-                MqttEvent::Disconnected(_) | MqttEvent::ReconnectNeeded => {
+                MqttEvent::Disconnected(_) | MqttEvent::ReconnectNeeded
                     if self.state != QuicConnState::Disconnecting
-                        && self.state != QuicConnState::Done
-                    {
-                        self.state = QuicConnState::Failed;
-                        outcome.error = true;
-                    }
+                        && self.state != QuicConnState::Done =>
+                {
+                    self.state = QuicConnState::Failed;
+                    outcome.error = true;
                 }
+
                 _ => {}
             }
         }
@@ -483,7 +483,7 @@ impl QuicConnection {
             return false;
         }
         let drained = self.messages_acked >= self.messages_sent
-            || self.drain_deadline.map_or(false, |d| now >= d);
+            || self.drain_deadline.is_some_and(|d| now >= d);
         if drained {
             self.engine.disconnect();
             let _ = self.engine.handle_tick(now);

--- a/mqtt_ring_bench/src/connection.rs
+++ b/mqtt_ring_bench/src/connection.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use flowsdk::mqtt_client::{MqttClientOptions, MqttEvent, NoIoMqttClient, PublishCommand};
 #[cfg(feature = "quic")]
 use flowsdk::mqtt_client::engine::QuicMqttEngine;
+use flowsdk::mqtt_client::{MqttClientOptions, MqttEvent, NoIoMqttClient, PublishCommand};
 use std::collections::VecDeque;
 #[cfg(feature = "quic")]
 use std::net::SocketAddr;
@@ -190,9 +190,7 @@ impl Connection {
             return false;
         }
         let drained = self.messages_acked >= self.messages_sent
-            || self
-                .drain_deadline
-                .map_or(false, |d| Instant::now() >= d);
+            || self.drain_deadline.map_or(false, |d| Instant::now() >= d);
         if drained {
             self.mqtt.disconnect();
             self.take_outgoing();
@@ -419,8 +417,7 @@ impl QuicConnection {
                 let _ = self.engine.handle_tick(now);
                 self.drain_outgoing_datagrams();
                 if config.interval_ms > 0 {
-                    self.next_publish_at =
-                        Some(now + Duration::from_millis(config.interval_ms));
+                    self.next_publish_at = Some(now + Duration::from_millis(config.interval_ms));
                 }
                 true
             }
@@ -475,9 +472,7 @@ impl QuicConnection {
     }
 
     pub fn check_publish_complete(&mut self) {
-        if self.state == QuicConnState::Publishing
-            && self.messages_sent >= self.messages_target
-        {
+        if self.state == QuicConnState::Publishing && self.messages_sent >= self.messages_target {
             self.state = QuicConnState::Draining;
             self.drain_deadline = Some(Instant::now() + Duration::from_secs(10));
         }

--- a/mqtt_ring_bench/src/main.rs
+++ b/mqtt_ring_bench/src/main.rs
@@ -12,10 +12,10 @@ mod connection;
 mod stats;
 #[cfg(target_os = "linux")]
 mod worker_common;
-#[cfg(target_os = "linux")]
-mod worker_tcp;
 #[cfg(all(target_os = "linux", feature = "quic"))]
 mod worker_quic;
+#[cfg(target_os = "linux")]
+mod worker_tcp;
 
 #[cfg(target_os = "linux")]
 use std::sync::atomic::Ordering;
@@ -79,7 +79,9 @@ fn main() {
             continue;
         }
 
-        handles.push(thread::spawn(move || worker_tcp::run_worker(w, range, cfg, st)));
+        handles.push(thread::spawn(move || {
+            worker_tcp::run_worker(w, range, cfg, st)
+        }));
     }
 
     // Stats reporter thread
@@ -147,7 +149,8 @@ fn print_banner(config: &config::BenchConfig) {
     if config.ifaddrs.is_empty() {
         eprintln!("  Bind addrs: (OS default)");
     } else {
-        eprintln!("  Bind addrs: {} IPs ({}..{})",
+        eprintln!(
+            "  Bind addrs: {} IPs ({}..{})",
             config.ifaddrs.len(),
             config.ifaddrs.first().unwrap(),
             config.ifaddrs.last().unwrap(),

--- a/mqtt_ring_bench/src/main.rs
+++ b/mqtt_ring_bench/src/main.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: MPL-2.0
+
+mod config;
+mod connection;
+mod stats;
+mod worker_common;
+mod worker_tcp;
+#[cfg(feature = "quic")]
+mod worker_quic;
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+    let config = Arc::new(config::parse_args());
+    let stats = Arc::new(stats::BenchStats::new());
+
+    print_banner(&config);
+
+    // Build TLS config for QUIC (if enabled)
+    #[cfg(feature = "quic")]
+    let quic_crypto: Option<Arc<rustls::ClientConfig>> = if config.quic {
+        Some(Arc::new(build_quic_crypto(&config)))
+    } else {
+        None
+    };
+
+    // Ctrl+C handler
+    let stats_ctrlc = Arc::clone(&stats);
+    ctrlc::set_handler(move || {
+        eprintln!("\nInterrupted, stopping...");
+        stats_ctrlc.stopped.store(true, Ordering::SeqCst);
+    })
+    .expect("failed to set Ctrl+C handler");
+
+    let workers = config.workers.min(config.clients);
+    let clients_per_worker = config.clients / workers;
+    let remainder = config.clients % workers;
+
+    // Spawn worker threads
+    let mut handles = Vec::with_capacity(workers);
+    let mut offset = 0;
+    for w in 0..workers {
+        let n = clients_per_worker + if w < remainder { 1 } else { 0 };
+        let range = offset..offset + n;
+        offset += n;
+
+        let cfg = Arc::clone(&config);
+        let st = Arc::clone(&stats);
+
+        #[cfg(feature = "quic")]
+        if let Some(ref crypto) = quic_crypto {
+            let crypto = Arc::clone(crypto);
+            handles.push(thread::spawn(move || {
+                worker_quic::run_quic_worker(w, range, cfg, st, crypto)
+            }));
+            continue;
+        }
+
+        handles.push(thread::spawn(move || worker_tcp::run_worker(w, range, cfg, st)));
+    }
+
+    // Stats reporter thread
+    let stats_reporter = Arc::clone(&stats);
+    let total_clients = config.clients as u64;
+    let total_messages = config.clients as u64 * config.messages;
+    let reporter = thread::spawn(move || {
+        let mut prev_sent: u64 = 0;
+        loop {
+            thread::sleep(Duration::from_secs(1));
+            let snap = stats_reporter.snapshot();
+            let rate = snap.sent.saturating_sub(prev_sent);
+            prev_sent = snap.sent;
+            let secs = snap.elapsed.as_secs();
+            eprint!(
+                "\r[{:>4}s] Connected: {}/{} | Sent: {}/{} | Acked: {} | Errors: {} | Rate: {} msg/s   ",
+                secs, snap.connected, total_clients, snap.sent, total_messages, snap.acked, snap.errors, rate
+            );
+            if snap.done >= total_clients || stats_reporter.stopped.load(Ordering::Relaxed) {
+                eprintln!();
+                break;
+            }
+        }
+    });
+
+    // Wait for all workers
+    let mut all_samples: Vec<Vec<Duration>> = Vec::new();
+    for h in handles {
+        match h.join() {
+            Ok(result) => all_samples.push(result.latency_samples),
+            Err(_) => eprintln!("worker thread panicked"),
+        }
+    }
+    let _ = reporter.join();
+
+    let merged = stats::merge_latency_samples(all_samples);
+    let snap = stats.snapshot();
+    stats::print_final_summary(&config, &snap, &merged);
+}
+
+fn print_banner(config: &config::BenchConfig) {
+    let transport = if config.quic { "QUIC" } else { "TCP" };
+    eprintln!("mqtt_ring_bench - io_uring MQTT publish benchmark");
+    eprintln!(
+        "  Target:     {}:{} ({})",
+        config.host, config.port, transport
+    );
+    eprintln!("  Clients:    {}", config.clients);
+    eprintln!("  Workers:    {}", config.workers);
+    eprintln!("  Messages:   {} per client", config.messages);
+    eprintln!("  QoS:        {}", config.qos);
+    eprintln!("  Payload:    {} bytes", config.payload_size);
+    eprintln!(
+        "  Interval:   {} ms",
+        if config.interval_ms == 0 {
+            "max speed".to_string()
+        } else {
+            config.interval_ms.to_string()
+        }
+    );
+    eprintln!("  MQTT:       v{}", config.mqtt_version);
+    eprintln!("  Socket buf: {} bytes", config.socket_buf);
+    eprintln!("  Parser buf: {} bytes", config.parser_buf);
+    if config.ifaddrs.is_empty() {
+        eprintln!("  Bind addrs: (OS default)");
+    } else {
+        eprintln!("  Bind addrs: {} IPs ({}..{})",
+            config.ifaddrs.len(),
+            config.ifaddrs.first().unwrap(),
+            config.ifaddrs.last().unwrap(),
+        );
+    }
+    if config.quic {
+        let sni = config.server_name.as_deref().unwrap_or(&config.host);
+        eprintln!("  TLS SNI:    {}", sni);
+        if config.quic_insecure {
+            eprintln!("  TLS verify: DISABLED (insecure)");
+        }
+    }
+    eprintln!();
+}
+
+#[cfg(feature = "quic")]
+fn build_quic_crypto(config: &config::BenchConfig) -> rustls::ClientConfig {
+    if config.quic_insecure {
+        rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(InsecureCertVerifier))
+            .with_no_client_auth()
+    } else {
+        let mut root_store = rustls::RootCertStore::empty();
+        for cert in rustls_native_certs::load_native_certs().unwrap_or_default() {
+            root_store.add(cert).ok();
+        }
+        if root_store.is_empty() {
+            eprintln!("Warning: no system root certificates found; TLS verification may fail.");
+            eprintln!("         Use --quic-insecure for testing without certificate verification.");
+        }
+        rustls::ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth()
+    }
+}
+
+/// Certificate verifier that accepts any server certificate (for --quic-insecure).
+#[cfg(feature = "quic")]
+#[derive(Debug)]
+struct InsecureCertVerifier;
+
+#[cfg(feature = "quic")]
+impl rustls::client::danger::ServerCertVerifier for InsecureCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls_pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls_pki_types::CertificateDer<'_>],
+        _server_name: &rustls_pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls_pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls_pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls_pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}

--- a/mqtt_ring_bench/src/main.rs
+++ b/mqtt_ring_bench/src/main.rs
@@ -1,18 +1,38 @@
 // SPDX-License-Identifier: MPL-2.0
 
+// Linux-only: this bench is built on io_uring. On non-Linux platforms we
+// fall through to a stub `main` below so workspace builds (e.g. macOS CI)
+// still succeed.
+
+#[cfg(target_os = "linux")]
 mod config;
+#[cfg(target_os = "linux")]
 mod connection;
+#[cfg(target_os = "linux")]
 mod stats;
+#[cfg(target_os = "linux")]
 mod worker_common;
+#[cfg(target_os = "linux")]
 mod worker_tcp;
-#[cfg(feature = "quic")]
+#[cfg(all(target_os = "linux", feature = "quic"))]
 mod worker_quic;
 
+#[cfg(target_os = "linux")]
 use std::sync::atomic::Ordering;
+#[cfg(target_os = "linux")]
 use std::sync::Arc;
+#[cfg(target_os = "linux")]
 use std::thread;
+#[cfg(target_os = "linux")]
 use std::time::Duration;
 
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("mqtt_ring_bench is Linux-only (built on io_uring).");
+    std::process::exit(1);
+}
+
+#[cfg(target_os = "linux")]
 fn main() {
     let config = Arc::new(config::parse_args());
     let stats = Arc::new(stats::BenchStats::new());
@@ -100,6 +120,7 @@ fn main() {
     stats::print_final_summary(&config, &snap, &merged);
 }
 
+#[cfg(target_os = "linux")]
 fn print_banner(config: &config::BenchConfig) {
     let transport = if config.quic { "QUIC" } else { "TCP" };
     eprintln!("mqtt_ring_bench - io_uring MQTT publish benchmark");
@@ -142,7 +163,7 @@ fn print_banner(config: &config::BenchConfig) {
     eprintln!();
 }
 
-#[cfg(feature = "quic")]
+#[cfg(all(target_os = "linux", feature = "quic"))]
 fn build_quic_crypto(config: &config::BenchConfig) -> rustls::ClientConfig {
     if config.quic_insecure {
         rustls::ClientConfig::builder()
@@ -165,11 +186,11 @@ fn build_quic_crypto(config: &config::BenchConfig) -> rustls::ClientConfig {
 }
 
 /// Certificate verifier that accepts any server certificate (for --quic-insecure).
-#[cfg(feature = "quic")]
+#[cfg(all(target_os = "linux", feature = "quic"))]
 #[derive(Debug)]
 struct InsecureCertVerifier;
 
-#[cfg(feature = "quic")]
+#[cfg(all(target_os = "linux", feature = "quic"))]
 impl rustls::client::danger::ServerCertVerifier for InsecureCertVerifier {
     fn verify_server_cert(
         &self,

--- a/mqtt_ring_bench/src/stats.rs
+++ b/mqtt_ring_bench/src/stats.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+pub struct BenchStats {
+    pub messages_sent: AtomicU64,
+    pub messages_acked: AtomicU64,
+    pub errors: AtomicU64,
+    pub clients_connected: AtomicU64,
+    pub clients_done: AtomicU64,
+    pub start_time: Instant,
+    pub stopped: AtomicBool,
+}
+
+impl BenchStats {
+    pub fn new() -> Self {
+        Self {
+            messages_sent: AtomicU64::new(0),
+            messages_acked: AtomicU64::new(0),
+            errors: AtomicU64::new(0),
+            clients_connected: AtomicU64::new(0),
+            clients_done: AtomicU64::new(0),
+            start_time: Instant::now(),
+            stopped: AtomicBool::new(false),
+        }
+    }
+
+    pub fn snapshot(&self) -> StatsSnapshot {
+        StatsSnapshot {
+            sent: self.messages_sent.load(Ordering::Relaxed),
+            acked: self.messages_acked.load(Ordering::Relaxed),
+            errors: self.errors.load(Ordering::Relaxed),
+            connected: self.clients_connected.load(Ordering::Relaxed),
+            done: self.clients_done.load(Ordering::Relaxed),
+            elapsed: self.start_time.elapsed(),
+        }
+    }
+}
+
+pub struct StatsSnapshot {
+    pub sent: u64,
+    pub acked: u64,
+    pub errors: u64,
+    pub connected: u64,
+    pub done: u64,
+    pub elapsed: Duration,
+}
+
+pub fn merge_latency_samples(worker_samples: Vec<Vec<Duration>>) -> Vec<Duration> {
+    let total: usize = worker_samples.iter().map(|v| v.len()).sum();
+    let mut merged = Vec::with_capacity(total);
+    for mut samples in worker_samples {
+        merged.append(&mut samples);
+    }
+    merged.sort_unstable();
+    merged
+}
+
+pub fn percentile(sorted: &[Duration], pct: f64) -> Duration {
+    if sorted.is_empty() {
+        return Duration::ZERO;
+    }
+    let idx = ((sorted.len() as f64 - 1.0) * pct / 100.0) as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+pub fn print_final_summary(
+    config: &crate::config::BenchConfig,
+    snap: &StatsSnapshot,
+    latency_samples: &[Duration],
+) {
+    let duration_secs = snap.elapsed.as_secs_f64();
+    let throughput = if duration_secs > 0.0 {
+        snap.sent as f64 / duration_secs
+    } else {
+        0.0
+    };
+
+    let sep = "=".repeat(60);
+    let dash = "-".repeat(60);
+    println!("\n{sep}");
+    println!("{:^60}", "MQTT Bench Results");
+    println!("{sep}");
+    let transport = if config.quic { "QUIC" } else { "TCP" };
+    println!("  Broker:          {}:{} ({})", config.host, config.port, transport);
+    println!("  MQTT Version:    {}", config.mqtt_version);
+    println!("  Clients:         {}", config.clients);
+    println!("  Workers:         {}", config.workers);
+    println!("  QoS:             {}", config.qos);
+    println!("  Payload Size:    {} bytes", config.payload_size);
+    println!("  Messages/Client: {}", config.messages);
+    println!("  Socket Buffers:  {} bytes", config.socket_buf);
+    println!("  Parser Buffer:   {} bytes", config.parser_buf);
+    println!("{dash}");
+    println!("  Total Sent:      {}", snap.sent);
+    if config.qos > 0 {
+        println!("  Total Acked:     {}", snap.acked);
+    }
+    println!("  Errors:          {}", snap.errors);
+    println!("  Duration:        {:.2} s", duration_secs);
+    println!("  Throughput:      {:.2} msg/s", throughput);
+
+    if !latency_samples.is_empty() {
+        println!("{dash}");
+        let label = if config.qos == 0 {
+            "Latency (enqueue time)"
+        } else {
+            "Latency (send -> ACK)"
+        };
+        println!("  {}:", label);
+        let avg: Duration =
+            latency_samples.iter().sum::<Duration>() / latency_samples.len() as u32;
+        println!("    Min:           {:.2} ms", ms(latency_samples[0]));
+        println!(
+            "    Max:           {:.2} ms",
+            ms(*latency_samples.last().unwrap())
+        );
+        println!("    Avg:           {:.2} ms", ms(avg));
+        println!(
+            "    P50:           {:.2} ms",
+            ms(percentile(latency_samples, 50.0))
+        );
+        println!(
+            "    P95:           {:.2} ms",
+            ms(percentile(latency_samples, 95.0))
+        );
+        println!(
+            "    P99:           {:.2} ms",
+            ms(percentile(latency_samples, 99.0))
+        );
+        println!("    Samples:       {}", latency_samples.len());
+    }
+    println!("{sep}");
+}
+
+fn ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1000.0
+}

--- a/mqtt_ring_bench/src/stats.rs
+++ b/mqtt_ring_bench/src/stats.rs
@@ -83,7 +83,10 @@ pub fn print_final_summary(
     println!("{:^60}", "MQTT Bench Results");
     println!("{sep}");
     let transport = if config.quic { "QUIC" } else { "TCP" };
-    println!("  Broker:          {}:{} ({})", config.host, config.port, transport);
+    println!(
+        "  Broker:          {}:{} ({})",
+        config.host, config.port, transport
+    );
     println!("  MQTT Version:    {}", config.mqtt_version);
     println!("  Clients:         {}", config.clients);
     println!("  Workers:         {}", config.workers);
@@ -109,8 +112,7 @@ pub fn print_final_summary(
             "Latency (send -> ACK)"
         };
         println!("  {}:", label);
-        let avg: Duration =
-            latency_samples.iter().sum::<Duration>() / latency_samples.len() as u32;
+        let avg: Duration = latency_samples.iter().sum::<Duration>() / latency_samples.len() as u32;
         println!("    Min:           {:.2} ms", ms(latency_samples[0]));
         println!(
             "    Max:           {:.2} ms",

--- a/mqtt_ring_bench/src/worker_common.rs
+++ b/mqtt_ring_bench/src/worker_common.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use std::time::Duration;
+
+pub const OP_CONNECT: u64 = 0;
+pub const OP_SEND: u64 = 1;
+pub const OP_RECV: u64 = 2;
+
+pub fn encode_user_data(conn_key: usize, op: u64) -> u64 {
+    (op << 48) | (conn_key as u64)
+}
+
+pub fn decode_user_data(data: u64) -> (usize, u64) {
+    let conn_key = (data & 0x0000_FFFF_FFFF_FFFF) as usize;
+    let op = data >> 48;
+    (conn_key, op)
+}
+
+pub struct WorkerResult {
+    pub latency_samples: Vec<Duration>,
+}

--- a/mqtt_ring_bench/src/worker_quic.rs
+++ b/mqtt_ring_bench/src/worker_quic.rs
@@ -325,13 +325,7 @@ fn create_udp_socket(
 /// This sets the default peer so Send/Recv work like on a connected socket.
 fn udp_connect(fd: RawFd, addr: &std::net::SocketAddr) -> i32 {
     let sa = SockAddr::from(*addr);
-    unsafe {
-        libc::connect(
-            fd,
-            sa.as_ptr() as *const libc::sockaddr,
-            sa.len() as libc::socklen_t,
-        )
-    }
+    unsafe { libc::connect(fd, sa.as_ptr(), sa.len() as libc::socklen_t) }
 }
 
 fn handle_send_complete(

--- a/mqtt_ring_bench/src/worker_quic.rs
+++ b/mqtt_ring_bench/src/worker_quic.rs
@@ -89,7 +89,9 @@ pub fn run_quic_worker(
                                 "worker {}: UDP connect failed for client {}: {}",
                                 worker_id, client_idx, e
                             );
-                            unsafe { libc::close(fd); }
+                            unsafe {
+                                libc::close(fd);
+                            }
                             stats.errors.fetch_add(1, Ordering::Relaxed);
                             stats.clients_done.fetch_add(1, Ordering::Relaxed);
                             done_count += 1;
@@ -112,7 +114,9 @@ pub fn run_quic_worker(
                                             "worker {}: QUIC connect failed for client {}: {}",
                                             worker_id, client_idx, e
                                         );
-                                        unsafe { libc::close(fd); }
+                                        unsafe {
+                                            libc::close(fd);
+                                        }
                                         stats.errors.fetch_add(1, Ordering::Relaxed);
                                         stats.clients_done.fetch_add(1, Ordering::Relaxed);
                                         done_count += 1;
@@ -124,7 +128,9 @@ pub fn run_quic_worker(
                                     "worker {}: QuicConnection::new failed for client {}: {}",
                                     worker_id, client_idx, e
                                 );
-                                unsafe { libc::close(fd); }
+                                unsafe {
+                                    libc::close(fd);
+                                }
                                 stats.errors.fetch_add(1, Ordering::Relaxed);
                                 stats.clients_done.fetch_add(1, Ordering::Relaxed);
                                 done_count += 1;
@@ -174,12 +180,23 @@ pub fn run_quic_worker(
             match op {
                 OP_SEND => {
                     handle_send_complete(
-                        &mut conns, conn_key, result, &mut ring, &stats, &mut done_count,
+                        &mut conns,
+                        conn_key,
+                        result,
+                        &mut ring,
+                        &stats,
+                        &mut done_count,
                     );
                 }
                 OP_RECV => {
                     handle_recv_complete(
-                        &mut conns, conn_key, result, &mut ring, &config, &stats, &mut done_count,
+                        &mut conns,
+                        conn_key,
+                        result,
+                        &mut ring,
+                        &config,
+                        &stats,
+                        &mut done_count,
                     );
                 }
                 _ => {}
@@ -192,9 +209,7 @@ pub fn run_quic_worker(
         {
             let keys: Vec<usize> = conns
                 .iter()
-                .filter(|(_, c)| {
-                    c.state != QuicConnState::Done && c.state != QuicConnState::Failed
-                })
+                .filter(|(_, c)| c.state != QuicConnState::Done && c.state != QuicConnState::Failed)
                 .map(|(k, _)| k)
                 .collect();
             for key in keys {
@@ -310,7 +325,13 @@ fn create_udp_socket(
 /// This sets the default peer so Send/Recv work like on a connected socket.
 fn udp_connect(fd: RawFd, addr: &std::net::SocketAddr) -> i32 {
     let sa = SockAddr::from(*addr);
-    unsafe { libc::connect(fd, sa.as_ptr() as *const libc::sockaddr, sa.len() as libc::socklen_t) }
+    unsafe {
+        libc::connect(
+            fd,
+            sa.as_ptr() as *const libc::sockaddr,
+            sa.len() as libc::socklen_t,
+        )
+    }
 }
 
 fn handle_send_complete(

--- a/mqtt_ring_bench/src/worker_quic.rs
+++ b/mqtt_ring_bench/src/worker_quic.rs
@@ -1,0 +1,473 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use io_uring::opcode;
+use io_uring::types::{Fd, SubmitArgs, Timespec};
+use io_uring::IoUring;
+use slab::Slab;
+use socket2::{Domain, SockAddr, Socket, Type};
+use std::os::fd::IntoRawFd;
+use std::os::fd::RawFd;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::config::BenchConfig;
+use crate::connection::{QuicConnState, QuicConnection};
+use crate::stats::BenchStats;
+use crate::worker_common::{decode_user_data, encode_user_data, WorkerResult, OP_RECV, OP_SEND};
+
+pub fn run_quic_worker(
+    worker_id: usize,
+    conn_range: std::ops::Range<usize>,
+    config: Arc<BenchConfig>,
+    stats: Arc<BenchStats>,
+    crypto: Arc<rustls::ClientConfig>,
+) -> WorkerResult {
+    let num_conns = conn_range.len();
+    if num_conns == 0 {
+        return WorkerResult {
+            latency_samples: Vec::new(),
+        };
+    }
+
+    let ring_size = 4096u32.min((num_conns as u32 * 3).next_power_of_two().max(64));
+    let mut ring: IoUring = IoUring::builder()
+        .build(ring_size)
+        .unwrap_or_else(|e| panic!("worker {}: failed to create io_uring: {}", worker_id, e));
+
+    let mut conns: Slab<Box<QuicConnection>> = Slab::with_capacity(num_conns);
+
+    let server_name = config
+        .server_name
+        .as_deref()
+        .unwrap_or(&config.host)
+        .to_string();
+
+    let budget_per_sec = config.connect_rate / config.workers.max(1);
+    let mut connect_budget: f64 = 0.0;
+    let mut last_budget_tick = Instant::now();
+    let mut pending_create: Vec<usize> = conn_range.collect();
+    pending_create.reverse();
+
+    let mut done_count: usize = 0;
+    let mut last_timer_check = Instant::now();
+    let mut ifaddr_idx: usize = 0;
+
+    loop {
+        if stats.stopped.load(Ordering::Relaxed) {
+            break;
+        }
+
+        let now = Instant::now();
+
+        // Replenish connect budget
+        let elapsed_secs = now.duration_since(last_budget_tick).as_secs_f64();
+        if elapsed_secs >= 0.01 {
+            connect_budget += budget_per_sec as f64 * elapsed_secs;
+            if connect_budget > pending_create.len() as f64 {
+                connect_budget = pending_create.len() as f64;
+            }
+            last_budget_tick = now;
+        }
+
+        // Create UDP sockets, initiate QUIC handshake
+        while connect_budget >= 1.0 {
+            if let Some(client_idx) = pending_create.pop() {
+                let bind_ip = if config.ifaddrs.is_empty() {
+                    None
+                } else {
+                    let ip = config.ifaddrs[ifaddr_idx % config.ifaddrs.len()];
+                    ifaddr_idx += 1;
+                    Some(ip)
+                };
+                match create_udp_socket(&config, bind_ip) {
+                    Ok(fd) => {
+                        // "connect" the UDP socket so Send/Recv work without sendto/recvfrom
+                        let ret = udp_connect(fd, &config.addr);
+                        if ret < 0 {
+                            let e = std::io::Error::last_os_error();
+                            eprintln!(
+                                "worker {}: UDP connect failed for client {}: {}",
+                                worker_id, client_idx, e
+                            );
+                            unsafe { libc::close(fd); }
+                            stats.errors.fetch_add(1, Ordering::Relaxed);
+                            stats.clients_done.fetch_add(1, Ordering::Relaxed);
+                            done_count += 1;
+                            connect_budget -= 1.0;
+                            continue;
+                        }
+
+                        match QuicConnection::new(fd, client_idx, &config, config.addr) {
+                            Ok(mut conn) => {
+                                let crypto_clone = (*crypto).clone();
+                                match conn.initiate_quic_connect(crypto_clone, &server_name, now) {
+                                    Ok(()) => {
+                                        let key = conns.insert(Box::new(conn));
+                                        // Submit initial handshake datagrams + recv
+                                        submit_front_send(&mut ring, key, &mut conns[key]);
+                                        submit_recv(&mut ring, key, &mut conns[key]);
+                                    }
+                                    Err(e) => {
+                                        eprintln!(
+                                            "worker {}: QUIC connect failed for client {}: {}",
+                                            worker_id, client_idx, e
+                                        );
+                                        unsafe { libc::close(fd); }
+                                        stats.errors.fetch_add(1, Ordering::Relaxed);
+                                        stats.clients_done.fetch_add(1, Ordering::Relaxed);
+                                        done_count += 1;
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!(
+                                    "worker {}: QuicConnection::new failed for client {}: {}",
+                                    worker_id, client_idx, e
+                                );
+                                unsafe { libc::close(fd); }
+                                stats.errors.fetch_add(1, Ordering::Relaxed);
+                                stats.clients_done.fetch_add(1, Ordering::Relaxed);
+                                done_count += 1;
+                            }
+                        }
+                        connect_budget -= 1.0;
+                    }
+                    Err(e) => {
+                        eprintln!("worker {}: UDP socket creation failed: {}", worker_id, e);
+                        stats.errors.fetch_add(1, Ordering::Relaxed);
+                        stats.clients_done.fetch_add(1, Ordering::Relaxed);
+                        done_count += 1;
+                        connect_budget -= 1.0;
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+
+        // Wait up to 10ms for completions (QUIC needs frequent ticking)
+        let ts = Timespec::new().nsec(10_000_000); // 10ms
+        let args = SubmitArgs::new().timespec(&ts);
+        let wait_count = if conns.is_empty() { 0 } else { 1 };
+        match ring.submitter().submit_with_args(wait_count, &args) {
+            Ok(_) => {}
+            Err(ref e) if e.raw_os_error() == Some(libc::EINTR) => continue,
+            Err(ref e) if e.raw_os_error() == Some(libc::EBUSY) => continue,
+            Err(ref e) if e.raw_os_error() == Some(libc::ETIME) => {} // timeout, continue
+            Err(e) => {
+                eprintln!("worker {}: io_uring submit error: {}", worker_id, e);
+                break;
+            }
+        }
+
+        // Process completions
+        let now = Instant::now();
+        let cqes: Vec<_> = ring.completion().collect();
+        for cqe in cqes {
+            let (conn_key, op) = decode_user_data(cqe.user_data());
+            let result = cqe.result();
+
+            if !conns.contains(conn_key) {
+                continue;
+            }
+
+            match op {
+                OP_SEND => {
+                    handle_send_complete(
+                        &mut conns, conn_key, result, &mut ring, &stats, &mut done_count,
+                    );
+                }
+                OP_RECV => {
+                    handle_recv_complete(
+                        &mut conns, conn_key, result, &mut ring, &config, &stats, &mut done_count,
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        // Try to publish on ready connections + handle ticks (~10ms)
+        if now.duration_since(last_timer_check) >= Duration::from_millis(10) {
+            last_timer_check = now;
+            let keys: Vec<usize> = conns
+                .iter()
+                .filter(|(_, c)| {
+                    c.state != QuicConnState::Done && c.state != QuicConnState::Failed
+                })
+                .map(|(k, _)| k)
+                .collect();
+            for key in keys {
+                let conn = &mut conns[key];
+
+                // Drive QUIC state machine
+                let events = conn.handle_tick(now);
+                if !events.is_empty() {
+                    let outcome = conn.process_events(events);
+                    if outcome.connected {
+                        stats.clients_connected.fetch_add(1, Ordering::Relaxed);
+                    }
+                    if outcome.acked > 0 {
+                        stats
+                            .messages_acked
+                            .fetch_add(outcome.acked, Ordering::Relaxed);
+                    }
+                    if outcome.error {
+                        stats.errors.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+
+                // Try publish
+                if conn.state == QuicConnState::Publishing {
+                    if conn.try_publish(&config, now) {
+                        stats.messages_sent.fetch_add(1, Ordering::Relaxed);
+                    }
+                    conn.check_publish_complete();
+                }
+
+                // Check drain
+                if conn.state == QuicConnState::Draining {
+                    conn.check_drain_complete(now);
+                }
+
+                // Check if disconnecting is done (no more sends pending)
+                if conn.state == QuicConnState::Disconnecting
+                    && !conn.has_pending_send()
+                    && !conn.send_pending
+                {
+                    conn.state = QuicConnState::Done;
+                    stats.clients_done.fetch_add(1, Ordering::Relaxed);
+                    done_count += 1;
+                }
+
+                // Submit any new outgoing datagrams
+                if conn.has_pending_send() && !conn.send_pending {
+                    submit_front_send(&mut ring, key, conn);
+                }
+            }
+        }
+
+        if done_count >= num_conns && pending_create.is_empty() {
+            break;
+        }
+    }
+
+    // Collect latency samples
+    let mut all_samples = Vec::new();
+    for (_, conn) in conns.iter_mut() {
+        all_samples.append(&mut conn.latency_samples);
+    }
+
+    // Close fds
+    for (_, conn) in conns.iter() {
+        unsafe {
+            libc::close(conn.fd);
+        }
+    }
+
+    WorkerResult {
+        latency_samples: all_samples,
+    }
+}
+
+fn create_udp_socket(
+    config: &BenchConfig,
+    bind_addr: Option<std::net::IpAddr>,
+) -> std::io::Result<RawFd> {
+    let domain = if config.addr.is_ipv4() {
+        Domain::IPV4
+    } else {
+        Domain::IPV6
+    };
+    let socket = Socket::new(domain, Type::DGRAM, None)?;
+    socket.set_nonblocking(true)?;
+    socket.set_recv_buffer_size(config.socket_buf)?;
+    socket.set_send_buffer_size(config.socket_buf)?;
+
+    let bind_sa = match bind_addr {
+        Some(ip) => SockAddr::from(std::net::SocketAddr::new(ip, 0)),
+        None => {
+            // Bind to 0.0.0.0:0 so the OS assigns an ephemeral port
+            if config.addr.is_ipv4() {
+                SockAddr::from(std::net::SocketAddr::new(
+                    std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+                    0,
+                ))
+            } else {
+                SockAddr::from(std::net::SocketAddr::new(
+                    std::net::IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
+                    0,
+                ))
+            }
+        }
+    };
+    socket.bind(&bind_sa)?;
+
+    Ok(socket.into_raw_fd())
+}
+
+/// Connect a UDP socket to the given address using libc::connect.
+/// This sets the default peer so Send/Recv work like on a connected socket.
+fn udp_connect(fd: RawFd, addr: &std::net::SocketAddr) -> i32 {
+    let sa = SockAddr::from(*addr);
+    unsafe { libc::connect(fd, sa.as_ptr() as *const libc::sockaddr, sa.len() as libc::socklen_t) }
+}
+
+fn handle_send_complete(
+    conns: &mut Slab<Box<QuicConnection>>,
+    key: usize,
+    result: i32,
+    ring: &mut IoUring,
+    stats: &BenchStats,
+    done_count: &mut usize,
+) {
+    let conn = &mut conns[key];
+    conn.send_pending = false;
+
+    if result < 0 {
+        let err_code = -result;
+        eprintln!(
+            "connection {}: UDP send failed: {}",
+            conn.client_index,
+            std::io::Error::from_raw_os_error(err_code)
+        );
+        mark_failed(conn, stats, done_count);
+        return;
+    }
+
+    // Datagram sent successfully; pop it from the queue
+    conn.pop_front_datagram();
+
+    // If more datagrams in queue, submit next send
+    if conn.has_pending_send() {
+        submit_front_send(ring, key, conn);
+    }
+}
+
+fn handle_recv_complete(
+    conns: &mut Slab<Box<QuicConnection>>,
+    key: usize,
+    result: i32,
+    ring: &mut IoUring,
+    config: &BenchConfig,
+    stats: &BenchStats,
+    done_count: &mut usize,
+) {
+    let conn = &mut conns[key];
+    conn.recv_pending = false;
+
+    if result <= 0 {
+        if result < 0 {
+            let err_code = -result;
+            // ECONNREFUSED is common for UDP when the remote port is closed
+            if err_code != libc::ECONNREFUSED {
+                eprintln!(
+                    "connection {}: UDP recv error: {}",
+                    conn.client_index,
+                    std::io::Error::from_raw_os_error(err_code)
+                );
+            }
+        }
+        if conn.state != QuicConnState::Done && conn.state != QuicConnState::Disconnecting {
+            mark_failed(conn, stats, done_count);
+        }
+        return;
+    }
+
+    let nbytes = result as usize;
+    let now = Instant::now();
+
+    // Feed datagram to QUIC engine
+    let data: Vec<u8> = conn.recv_buf[..nbytes].to_vec();
+    let events = conn.handle_datagram(&data, now);
+
+    if !events.is_empty() {
+        let outcome = conn.process_events(events);
+        if outcome.connected {
+            stats.clients_connected.fetch_add(1, Ordering::Relaxed);
+        }
+        if outcome.acked > 0 {
+            stats
+                .messages_acked
+                .fetch_add(outcome.acked, Ordering::Relaxed);
+        }
+        if outcome.error {
+            stats.errors.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    // Try to publish after receiving (may have transitioned to Publishing)
+    if conn.state == QuicConnState::Publishing {
+        if conn.try_publish(config, now) {
+            stats.messages_sent.fetch_add(1, Ordering::Relaxed);
+        }
+        conn.check_publish_complete();
+    }
+
+    if conn.state == QuicConnState::Draining {
+        conn.check_drain_complete(now);
+    }
+
+    // Submit outgoing datagrams
+    if conn.has_pending_send() && !conn.send_pending {
+        submit_front_send(ring, key, conn);
+    }
+
+    // Continue receiving (unless done/failed)
+    if conn.state != QuicConnState::Done && conn.state != QuicConnState::Failed {
+        submit_recv(ring, key, conn);
+    }
+}
+
+fn mark_failed(conn: &mut QuicConnection, stats: &BenchStats, done_count: &mut usize) {
+    if conn.state != QuicConnState::Failed && conn.state != QuicConnState::Done {
+        conn.state = QuicConnState::Failed;
+        stats.errors.fetch_add(1, Ordering::Relaxed);
+        stats.clients_done.fetch_add(1, Ordering::Relaxed);
+        *done_count += 1;
+    }
+}
+
+fn submit_front_send(ring: &mut IoUring, key: usize, conn: &mut QuicConnection) {
+    if conn.send_pending {
+        return;
+    }
+    let datagram = match conn.front_send_datagram() {
+        Some(d) => d,
+        None => return,
+    };
+    let ptr = datagram.as_ptr();
+    let len = datagram.len() as u32;
+
+    let send_e = opcode::Send::new(Fd(conn.fd), ptr, len)
+        .build()
+        .user_data(encode_user_data(key, OP_SEND));
+
+    conn.send_pending = true;
+    unsafe {
+        if ring.submission().push(&send_e).is_err() {
+            let _ = ring.submitter().submit();
+            let _ = ring.submission().push(&send_e);
+        }
+    }
+}
+
+fn submit_recv(ring: &mut IoUring, key: usize, conn: &mut QuicConnection) {
+    if conn.recv_pending {
+        return;
+    }
+    let buf_ptr = conn.recv_buf.as_mut_ptr();
+    let buf_len = conn.recv_buf.len() as u32;
+
+    let recv_e = opcode::Recv::new(Fd(conn.fd), buf_ptr, buf_len)
+        .build()
+        .user_data(encode_user_data(key, OP_RECV));
+
+    conn.recv_pending = true;
+    unsafe {
+        if ring.submission().push(&recv_e).is_err() {
+            let _ = ring.submitter().submit();
+            let _ = ring.submission().push(&recv_e);
+        }
+    }
+}

--- a/mqtt_ring_bench/src/worker_quic.rs
+++ b/mqtt_ring_bench/src/worker_quic.rs
@@ -9,7 +9,7 @@ use std::os::fd::IntoRawFd;
 use std::os::fd::RawFd;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use crate::config::BenchConfig;
 use crate::connection::{QuicConnState, QuicConnection};
@@ -50,7 +50,6 @@ pub fn run_quic_worker(
     pending_create.reverse();
 
     let mut done_count: usize = 0;
-    let mut last_timer_check = Instant::now();
     let mut ifaddr_idx: usize = 0;
 
     loop {
@@ -187,9 +186,10 @@ pub fn run_quic_worker(
             }
         }
 
-        // Try to publish on ready connections + handle ticks (~10ms)
-        if now.duration_since(last_timer_check) >= Duration::from_millis(10) {
-            last_timer_check = now;
+        // Drive QUIC + MQTT state machines. The io_uring wait timeout (10ms)
+        // provides the cadence; quinn-proto's loss detection and pacing need
+        // ticks at roughly that rate regardless of CQE arrivals.
+        {
             let keys: Vec<usize> = conns
                 .iter()
                 .filter(|(_, c)| {

--- a/mqtt_ring_bench/src/worker_tcp.rs
+++ b/mqtt_ring_bench/src/worker_tcp.rs
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use io_uring::opcode;
+use io_uring::types::{Fd, SubmitArgs, Timespec};
+use io_uring::IoUring;
+use slab::Slab;
+use socket2::{Domain, Protocol, SockAddr, Socket, Type};
+use std::os::fd::IntoRawFd;
+use std::os::fd::RawFd;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::config::BenchConfig;
+use crate::connection::{ConnState, Connection};
+use crate::stats::BenchStats;
+use crate::worker_common::{
+    decode_user_data, encode_user_data, WorkerResult, OP_CONNECT, OP_RECV, OP_SEND,
+};
+
+/// Each Connection is Box-allocated so its buffers have stable addresses
+/// for io_uring SQEs (Slab<T> may relocate entries on grow).
+pub fn run_worker(
+    worker_id: usize,
+    conn_range: std::ops::Range<usize>,
+    config: Arc<BenchConfig>,
+    stats: Arc<BenchStats>,
+) -> WorkerResult {
+    let num_conns = conn_range.len();
+    if num_conns == 0 {
+        return WorkerResult {
+            latency_samples: Vec::new(),
+        };
+    }
+
+    let ring_size = 4096u32.min((num_conns as u32 * 3).next_power_of_two().max(64));
+    let mut ring: IoUring = IoUring::builder()
+        .build(ring_size)
+        .unwrap_or_else(|e| panic!("worker {}: failed to create io_uring: {}", worker_id, e));
+
+    let mut conns: Slab<Box<Connection>> = Slab::with_capacity(num_conns);
+
+    // We need SockAddr to stay alive for the duration of connect SQEs.
+    // Keep one per in-flight connect. Once connected, it can be dropped.
+    let sock_addr = SockAddr::from(config.addr);
+    // Pin the SockAddr in a Box so its address is stable for io_uring.
+    let sock_addr_box = Box::new(sock_addr);
+    let sa_ptr = sock_addr_box.as_ref().as_ptr();
+    let sa_len = sock_addr_box.as_ref().len();
+
+    let budget_per_sec = config.connect_rate / config.workers.max(1);
+    let mut connect_budget: f64 = 0.0;
+    let mut last_budget_tick = Instant::now();
+    let mut pending_create: Vec<usize> = conn_range.collect();
+    pending_create.reverse();
+
+    let mut done_count: usize = 0;
+    let mut last_timer_check = Instant::now();
+    let mut ifaddr_idx: usize = 0;
+
+    loop {
+        if stats.stopped.load(Ordering::Relaxed) {
+            break;
+        }
+
+        let now = Instant::now();
+
+        // Replenish connect budget using fractional accumulation
+        let elapsed_secs = now.duration_since(last_budget_tick).as_secs_f64();
+        if elapsed_secs >= 0.01 {
+            connect_budget += budget_per_sec as f64 * elapsed_secs;
+            if connect_budget > pending_create.len() as f64 {
+                connect_budget = pending_create.len() as f64;
+            }
+            last_budget_tick = now;
+        }
+
+        // Create sockets and submit connect SQEs
+        while connect_budget >= 1.0 {
+            if let Some(client_idx) = pending_create.pop() {
+                let bind_ip = if config.ifaddrs.is_empty() {
+                    None
+                } else {
+                    let ip = config.ifaddrs[ifaddr_idx % config.ifaddrs.len()];
+                    ifaddr_idx += 1;
+                    Some(ip)
+                };
+                match create_socket(&config, bind_ip) {
+                    Ok(fd) => {
+                        let conn = Box::new(Connection::new(fd, client_idx, &config));
+                        let key = conns.insert(conn);
+
+                        let connect_e =
+                            opcode::Connect::new(Fd(fd), sa_ptr as *const _, sa_len)
+                                .build()
+                                .user_data(encode_user_data(key, OP_CONNECT));
+
+                        unsafe {
+                            if ring.submission().push(&connect_e).is_err() {
+                                // SQ full, submit and retry
+                                let _ = ring.submitter().submit();
+                                let _ = ring.submission().push(&connect_e);
+                            }
+                        }
+                        connect_budget -= 1.0;
+                    }
+                    Err(e) => {
+                        eprintln!("worker {}: socket creation failed: {}", worker_id, e);
+                        stats.errors.fetch_add(1, Ordering::Relaxed);
+                        stats.clients_done.fetch_add(1, Ordering::Relaxed);
+                        done_count += 1;
+                        connect_budget -= 1.0;
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+
+        // Wait up to 100ms for completions so Ctrl+C is checked on each iteration.
+        let ts = Timespec::new().nsec(100_000_000); // 100ms
+        let args = SubmitArgs::new().timespec(&ts);
+        let wait_count = if conns.is_empty() { 0 } else { 1 };
+        match ring.submitter().submit_with_args(wait_count, &args) {
+            Ok(_) => {}
+            Err(ref e) if e.raw_os_error() == Some(libc::EINTR) => continue,
+            Err(ref e) if e.raw_os_error() == Some(libc::EBUSY) => continue,
+            Err(ref e) if e.raw_os_error() == Some(libc::ETIME) => continue, // timeout, loop back
+            Err(e) => {
+                eprintln!("worker {}: io_uring submit error: {}", worker_id, e);
+                break;
+            }
+        }
+
+        // Process completions
+        let cqes: Vec<_> = ring.completion().collect();
+        for cqe in cqes {
+            let (conn_key, op) = decode_user_data(cqe.user_data());
+            let result = cqe.result();
+
+            if !conns.contains(conn_key) {
+                continue;
+            }
+
+            match op {
+                OP_CONNECT => {
+                    handle_connect_complete(&mut conns, conn_key, result, &mut ring, &stats);
+                }
+                OP_SEND => {
+                    handle_send_complete(
+                        &mut conns,
+                        conn_key,
+                        result,
+                        &mut ring,
+                        &config,
+                        &stats,
+                        &mut done_count,
+                    );
+                }
+                OP_RECV => {
+                    handle_recv_complete(
+                        &mut conns,
+                        conn_key,
+                        result,
+                        &mut ring,
+                        &config,
+                        &stats,
+                        &mut done_count,
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        // Try to publish on ready connections
+        let keys: Vec<usize> = conns
+            .iter()
+            .filter(|(_, c)| c.state == ConnState::Publishing && !c.send_pending)
+            .map(|(k, _)| k)
+            .collect();
+        for key in keys {
+            let conn = &mut conns[key];
+            if conn.try_publish(&config) {
+                stats.messages_sent.fetch_add(1, Ordering::Relaxed);
+                submit_send(&mut ring, key, conn);
+            }
+            conn.check_publish_complete();
+            if conn.state == ConnState::Draining && !conn.send_pending {
+                if conn.check_drain_complete() {
+                    submit_send(&mut ring, key, conn);
+                }
+            }
+        }
+
+        // Periodic timer checks (~500ms)
+        if now.duration_since(last_timer_check) >= Duration::from_millis(500) {
+            last_timer_check = now;
+            let keys: Vec<usize> = conns
+                .iter()
+                .filter(|(_, c)| {
+                    c.state != ConnState::Done
+                        && c.state != ConnState::Failed
+                        && c.state != ConnState::TcpConnecting
+                })
+                .map(|(k, _)| k)
+                .collect();
+            for key in keys {
+                let conn = &mut conns[key];
+                let events = conn.handle_tick();
+                if !events.is_empty() {
+                    let outcome = conn.process_events(events);
+                    if outcome.error {
+                        stats.errors.fetch_add(1, Ordering::Relaxed);
+                    }
+                    if outcome.acked > 0 {
+                        stats
+                            .messages_acked
+                            .fetch_add(outcome.acked, Ordering::Relaxed);
+                    }
+                    if conn.has_pending_send() && !conn.send_pending {
+                        submit_send(&mut ring, key, conn);
+                    }
+                }
+            }
+        }
+
+        if done_count >= num_conns && pending_create.is_empty() {
+            break;
+        }
+    }
+
+    // Collect latency samples
+    let mut all_samples = Vec::new();
+    for (_, conn) in conns.iter_mut() {
+        all_samples.append(&mut conn.latency_samples);
+    }
+
+    // Close fds
+    for (_, conn) in conns.iter() {
+        unsafe {
+            libc::close(conn.fd);
+        }
+    }
+
+    drop(sock_addr_box);
+
+    WorkerResult {
+        latency_samples: all_samples,
+    }
+}
+
+fn create_socket(
+    config: &BenchConfig,
+    bind_addr: Option<std::net::IpAddr>,
+) -> std::io::Result<RawFd> {
+    let domain = if config.addr.is_ipv4() {
+        Domain::IPV4
+    } else {
+        Domain::IPV6
+    };
+    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+    socket.set_nonblocking(true)?;
+    socket.set_nodelay(true)?;
+    socket.set_recv_buffer_size(config.socket_buf)?;
+    socket.set_send_buffer_size(config.socket_buf)?;
+
+    // Bind to a specific source IP; port 0 lets the OS pick an ephemeral port
+    if let Some(ip) = bind_addr {
+        let bind_sa = SockAddr::from(std::net::SocketAddr::new(ip, 0));
+        socket.bind(&bind_sa)?;
+    }
+
+    Ok(socket.into_raw_fd())
+}
+
+fn handle_connect_complete(
+    conns: &mut Slab<Box<Connection>>,
+    key: usize,
+    result: i32,
+    ring: &mut IoUring,
+    stats: &BenchStats,
+) {
+    let conn = &mut conns[key];
+    if result < 0 {
+        eprintln!(
+            "connection {}: TCP connect failed: {}",
+            conn.client_index,
+            std::io::Error::from_raw_os_error(-result)
+        );
+        conn.state = ConnState::Failed;
+        stats.errors.fetch_add(1, Ordering::Relaxed);
+        stats.clients_done.fetch_add(1, Ordering::Relaxed);
+        return;
+    }
+
+    stats.clients_connected.fetch_add(1, Ordering::Relaxed);
+    conn.initiate_mqtt_connect();
+    submit_send(ring, key, conn);
+    submit_recv(ring, key, conn);
+}
+
+fn handle_send_complete(
+    conns: &mut Slab<Box<Connection>>,
+    key: usize,
+    result: i32,
+    ring: &mut IoUring,
+    config: &BenchConfig,
+    stats: &BenchStats,
+    done_count: &mut usize,
+) {
+    let conn = &mut conns[key];
+    conn.send_pending = false;
+
+    if result < 0 {
+        let err_code = -result;
+        if err_code != libc::ECONNRESET && err_code != libc::EPIPE {
+            eprintln!(
+                "connection {}: send failed: {}",
+                conn.client_index,
+                std::io::Error::from_raw_os_error(err_code)
+            );
+        }
+        mark_failed(conn, stats, done_count);
+        return;
+    }
+
+    conn.advance_send(result as usize);
+
+    // Continue sending remaining bytes
+    if conn.has_pending_send() {
+        submit_send(ring, key, conn);
+        return;
+    }
+
+    match conn.state {
+        ConnState::Disconnecting => {
+            conn.state = ConnState::Done;
+            stats.clients_done.fetch_add(1, Ordering::Relaxed);
+            *done_count += 1;
+        }
+        ConnState::Publishing => {
+            if conn.try_publish(config) {
+                stats.messages_sent.fetch_add(1, Ordering::Relaxed);
+                submit_send(ring, key, conn);
+            }
+            conn.check_publish_complete();
+        }
+        _ => {}
+    }
+}
+
+fn handle_recv_complete(
+    conns: &mut Slab<Box<Connection>>,
+    key: usize,
+    result: i32,
+    ring: &mut IoUring,
+    config: &BenchConfig,
+    stats: &BenchStats,
+    done_count: &mut usize,
+) {
+    let conn = &mut conns[key];
+    conn.recv_pending = false;
+
+    if result <= 0 {
+        if result < 0 {
+            let err_code = -result;
+            if err_code != libc::ECONNRESET {
+                eprintln!(
+                    "connection {}: recv error: {}",
+                    conn.client_index,
+                    std::io::Error::from_raw_os_error(err_code)
+                );
+            }
+        }
+        if conn.state != ConnState::Done && conn.state != ConnState::Disconnecting {
+            mark_failed(conn, stats, done_count);
+        }
+        return;
+    }
+
+    let nbytes = result as usize;
+    // SAFETY: recv_buf is owned by the Box<Connection> which has a stable address.
+    // The kernel wrote into recv_buf during the recv operation.
+    // We must clone/copy the data before submitting the next recv on the same buffer.
+    let data: Vec<u8> = conn.recv_buf[..nbytes].to_vec();
+    let events = conn.handle_incoming(&data);
+
+    if !events.is_empty() {
+        let outcome = conn.process_events(events);
+        if outcome.acked > 0 {
+            stats
+                .messages_acked
+                .fetch_add(outcome.acked, Ordering::Relaxed);
+        }
+        if outcome.error {
+            stats.errors.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    match conn.state {
+        ConnState::Publishing => {
+            if conn.has_pending_send() && !conn.send_pending {
+                submit_send(ring, key, conn);
+            } else if !conn.send_pending && conn.try_publish(config) {
+                stats.messages_sent.fetch_add(1, Ordering::Relaxed);
+                submit_send(ring, key, conn);
+            }
+            conn.check_publish_complete();
+            submit_recv(ring, key, conn);
+        }
+        ConnState::MqttConnecting => {
+            if conn.has_pending_send() && !conn.send_pending {
+                submit_send(ring, key, conn);
+            }
+            submit_recv(ring, key, conn);
+        }
+        ConnState::Draining => {
+            if conn.check_drain_complete() {
+                if conn.has_pending_send() && !conn.send_pending {
+                    submit_send(ring, key, conn);
+                } else if !conn.has_pending_send() {
+                    conn.state = ConnState::Done;
+                    stats.clients_done.fetch_add(1, Ordering::Relaxed);
+                    *done_count += 1;
+                }
+            } else {
+                submit_recv(ring, key, conn);
+            }
+        }
+        ConnState::Failed | ConnState::Done => {}
+        _ => {
+            submit_recv(ring, key, conn);
+        }
+    }
+}
+
+fn mark_failed(conn: &mut Connection, stats: &BenchStats, done_count: &mut usize) {
+    if conn.state != ConnState::Failed && conn.state != ConnState::Done {
+        conn.state = ConnState::Failed;
+        stats.errors.fetch_add(1, Ordering::Relaxed);
+        stats.clients_done.fetch_add(1, Ordering::Relaxed);
+        *done_count += 1;
+    }
+}
+
+fn submit_send(ring: &mut IoUring, key: usize, conn: &mut Connection) {
+    if !conn.has_pending_send() || conn.send_pending {
+        return;
+    }
+    let slice = conn.pending_send_slice();
+    let ptr = slice.as_ptr();
+    let len = slice.len() as u32;
+
+    let send_e = opcode::Send::new(Fd(conn.fd), ptr, len)
+        .build()
+        .user_data(encode_user_data(key, OP_SEND));
+
+    conn.send_pending = true;
+    unsafe {
+        if ring.submission().push(&send_e).is_err() {
+            let _ = ring.submitter().submit();
+            let _ = ring.submission().push(&send_e);
+        }
+    }
+}
+
+fn submit_recv(ring: &mut IoUring, key: usize, conn: &mut Connection) {
+    if conn.recv_pending {
+        return;
+    }
+    let buf_ptr = conn.recv_buf.as_mut_ptr();
+    let buf_len = conn.recv_buf.len() as u32;
+
+    let recv_e = opcode::Recv::new(Fd(conn.fd), buf_ptr, buf_len)
+        .build()
+        .user_data(encode_user_data(key, OP_RECV));
+
+    conn.recv_pending = true;
+    unsafe {
+        if ring.submission().push(&recv_e).is_err() {
+            let _ = ring.submitter().submit();
+            let _ = ring.submission().push(&recv_e);
+        }
+    }
+}

--- a/mqtt_ring_bench/src/worker_tcp.rs
+++ b/mqtt_ring_bench/src/worker_tcp.rs
@@ -55,8 +55,10 @@ pub fn run_worker(
     pending_create.reverse();
 
     let mut done_count: usize = 0;
-    let mut last_timer_check = Instant::now();
     let mut ifaddr_idx: usize = 0;
+    // Upper bound on idle wait — keeps Ctrl+C / shutdown responsive even when
+    // no protocol timer is scheduled.
+    let max_idle_wait = Duration::from_secs(1);
 
     loop {
         if stats.stopped.load(Ordering::Relaxed) {
@@ -117,15 +119,31 @@ pub fn run_worker(
             }
         }
 
-        // Wait up to 100ms for completions so Ctrl+C is checked on each iteration.
-        let ts = Timespec::new().nsec(100_000_000); // 100ms
+        // Wait for the soonest of: next protocol deadline, a CQE arrival, or
+        // `max_idle_wait` (keeps shutdown responsive when nothing is scheduled).
+        let min_deadline = conns
+            .iter()
+            .filter(|(_, c)| {
+                c.state != ConnState::Done
+                    && c.state != ConnState::Failed
+                    && c.state != ConnState::TcpConnecting
+            })
+            .filter_map(|(_, c)| c.next_tick_at())
+            .min();
+        let wait_dur = match min_deadline {
+            Some(d) => d.saturating_duration_since(now).min(max_idle_wait),
+            None => max_idle_wait,
+        };
+        let wait_count = if conns.is_empty() || wait_dur.is_zero() { 0 } else { 1 };
+        let ts = Timespec::new()
+            .sec(wait_dur.as_secs())
+            .nsec(wait_dur.subsec_nanos());
         let args = SubmitArgs::new().timespec(&ts);
-        let wait_count = if conns.is_empty() { 0 } else { 1 };
         match ring.submitter().submit_with_args(wait_count, &args) {
             Ok(_) => {}
             Err(ref e) if e.raw_os_error() == Some(libc::EINTR) => continue,
             Err(ref e) if e.raw_os_error() == Some(libc::EBUSY) => continue,
-            Err(ref e) if e.raw_os_error() == Some(libc::ETIME) => continue, // timeout, loop back
+            Err(ref e) if e.raw_os_error() == Some(libc::ETIME) => {} // deadline hit, fall through to tick
             Err(e) => {
                 eprintln!("worker {}: io_uring submit error: {}", worker_id, e);
                 break;
@@ -192,35 +210,36 @@ pub fn run_worker(
             }
         }
 
-        // Periodic timer checks (~500ms)
-        if now.duration_since(last_timer_check) >= Duration::from_millis(500) {
-            last_timer_check = now;
-            let keys: Vec<usize> = conns
-                .iter()
-                .filter(|(_, c)| {
-                    c.state != ConnState::Done
-                        && c.state != ConnState::Failed
-                        && c.state != ConnState::TcpConnecting
-                })
-                .map(|(k, _)| k)
-                .collect();
-            for key in keys {
-                let conn = &mut conns[key];
-                let events = conn.handle_tick();
-                if !events.is_empty() {
-                    let outcome = conn.process_events(events);
-                    if outcome.error {
-                        stats.errors.fetch_add(1, Ordering::Relaxed);
-                    }
-                    if outcome.acked > 0 {
-                        stats
-                            .messages_acked
-                            .fetch_add(outcome.acked, Ordering::Relaxed);
-                    }
-                    if conn.has_pending_send() && !conn.send_pending {
-                        submit_send(&mut ring, key, conn);
-                    }
+        // Drive protocol timers. Connection::handle_tick is a cheap no-op if
+        // the per-connection deadline hasn't been reached, so iterating every
+        // loop pass is fine — and only happens when we either got a CQE or
+        // crossed the global min_deadline computed above.
+        let tick_keys: Vec<usize> = conns
+            .iter()
+            .filter(|(_, c)| {
+                c.state != ConnState::Done
+                    && c.state != ConnState::Failed
+                    && c.state != ConnState::TcpConnecting
+            })
+            .map(|(k, _)| k)
+            .collect();
+        for key in tick_keys {
+            let conn = &mut conns[key];
+            let events = conn.handle_tick();
+            if !events.is_empty() {
+                let outcome = conn.process_events(events);
+                if outcome.error {
+                    stats.errors.fetch_add(1, Ordering::Relaxed);
                 }
+                if outcome.acked > 0 {
+                    stats
+                        .messages_acked
+                        .fetch_add(outcome.acked, Ordering::Relaxed);
+                }
+            }
+            // PINGREQ / retransmits produce outgoing bytes without any event.
+            if conn.has_pending_send() && !conn.send_pending {
+                submit_send(&mut ring, key, conn);
             }
         }
 

--- a/mqtt_ring_bench/src/worker_tcp.rs
+++ b/mqtt_ring_bench/src/worker_tcp.rs
@@ -206,10 +206,11 @@ pub fn run_worker(
                 submit_send(&mut ring, key, conn);
             }
             conn.check_publish_complete();
-            if conn.state == ConnState::Draining && !conn.send_pending {
-                if conn.check_drain_complete() {
-                    submit_send(&mut ring, key, conn);
-                }
+            if conn.state == ConnState::Draining
+                && !conn.send_pending
+                && conn.check_drain_complete()
+            {
+                submit_send(&mut ring, key, conn);
             }
         }
 
@@ -419,6 +420,8 @@ fn handle_recv_complete(
         }
     }
 
+    let drain_complete = matches!(conn.state, ConnState::Draining) && conn.check_drain_complete();
+
     match conn.state {
         ConnState::Publishing => {
             if conn.has_pending_send() && !conn.send_pending {
@@ -436,18 +439,17 @@ fn handle_recv_complete(
             }
             submit_recv(ring, key, conn);
         }
-        ConnState::Draining => {
-            if conn.check_drain_complete() {
-                if conn.has_pending_send() && !conn.send_pending {
-                    submit_send(ring, key, conn);
-                } else if !conn.has_pending_send() {
-                    conn.state = ConnState::Done;
-                    stats.clients_done.fetch_add(1, Ordering::Relaxed);
-                    *done_count += 1;
-                }
-            } else {
-                submit_recv(ring, key, conn);
+        ConnState::Draining if drain_complete => {
+            if conn.has_pending_send() && !conn.send_pending {
+                submit_send(ring, key, conn);
+            } else if !conn.has_pending_send() {
+                conn.state = ConnState::Done;
+                stats.clients_done.fetch_add(1, Ordering::Relaxed);
+                *done_count += 1;
             }
+        }
+        ConnState::Draining => {
+            submit_recv(ring, key, conn);
         }
         ConnState::Failed | ConnState::Done => {}
         _ => {

--- a/mqtt_ring_bench/src/worker_tcp.rs
+++ b/mqtt_ring_bench/src/worker_tcp.rs
@@ -92,10 +92,9 @@ pub fn run_worker(
                         let conn = Box::new(Connection::new(fd, client_idx, &config));
                         let key = conns.insert(conn);
 
-                        let connect_e =
-                            opcode::Connect::new(Fd(fd), sa_ptr as *const _, sa_len)
-                                .build()
-                                .user_data(encode_user_data(key, OP_CONNECT));
+                        let connect_e = opcode::Connect::new(Fd(fd), sa_ptr as *const _, sa_len)
+                            .build()
+                            .user_data(encode_user_data(key, OP_CONNECT));
 
                         unsafe {
                             if ring.submission().push(&connect_e).is_err() {
@@ -134,7 +133,11 @@ pub fn run_worker(
             Some(d) => d.saturating_duration_since(now).min(max_idle_wait),
             None => max_idle_wait,
         };
-        let wait_count = if conns.is_empty() || wait_dur.is_zero() { 0 } else { 1 };
+        let wait_count = if conns.is_empty() || wait_dur.is_zero() {
+            0
+        } else {
+            1
+        };
         let ts = Timespec::new()
             .sec(wait_dur.as_secs())
             .nsec(wait_dur.subsec_nanos());

--- a/src/mqtt_client/engine.rs
+++ b/src/mqtt_client/engine.rs
@@ -122,7 +122,7 @@ impl MqttEngine {
     pub fn new(options: MqttClientOptions) -> Self {
         let mqtt_version = options.mqtt_version;
         // Default buffer size 16KB
-        let parser = MqttParser::new(16384, mqtt_version);
+        let parser = MqttParser::new(options.parser_buffer_size, mqtt_version);
 
         // Cache timeout values for efficiency
         let retransmission_timeout = Duration::from_millis(options.retransmission_timeout_ms);

--- a/src/mqtt_client/opts.rs
+++ b/src/mqtt_client/opts.rs
@@ -119,6 +119,13 @@ pub struct MqttClientOptions {
     /// - For outgoing: Limits how many QoS 1/2 messages can be inflight.
     /// - Default: 65535
     pub receive_maximum: u16,
+
+    /// Internal parser buffer size in bytes.
+    /// Controls the initial capacity of the MQTT packet parser's BytesMut buffer.
+    /// - Default: 16384 (16KB)
+    /// - For high-connection-count scenarios with small packets, use 1500 (1 MTU)
+    ///   to reduce per-connection memory overhead.
+    pub parser_buffer_size: usize,
 }
 
 impl Default for MqttClientOptions {
@@ -154,6 +161,7 @@ impl Default for MqttClientOptions {
             max_outgoing_packet_count: 1000,
             max_event_count: 1000,
             receive_maximum: 65535,
+            parser_buffer_size: 16384,
         }
     }
 }
@@ -571,6 +579,14 @@ impl MqttClientOptions {
     /// Set the Receive Maximum (MQTT v5)
     pub fn receive_maximum(mut self, max: u16) -> Self {
         self.receive_maximum = max;
+        self
+    }
+
+    /// Set the internal parser buffer size in bytes (default: 16384).
+    /// Use a smaller value (e.g., 1500 for 1 MTU) to reduce per-connection
+    /// memory in high-connection-count scenarios.
+    pub fn parser_buffer_size(mut self, size: usize) -> Self {
+        self.parser_buffer_size = size;
         self
     }
 }


### PR DESCRIPTION
- Implemented a new benchmarking tool for MQTT using io_uring for efficient asynchronous I/O operations.
- Introduced worker threads for handling TCP and QUIC connections, with support for configurable client and message parameters.
- Added statistics tracking for sent messages, acknowledgments, errors, and connection states.
- Enhanced the MQTT client options to allow customization of the internal parser buffer size.
- Updated the MQTT engine to utilize the configurable parser buffer size for improved performance in high-connection scenarios.

